### PR TITLE
feat(payments): implement payout readiness and onboarding status checks

### DIFF
--- a/.github/workflows/cron-jobs.yml
+++ b/.github/workflows/cron-jobs.yml
@@ -57,6 +57,12 @@ jobs:
             -H "Authorization: Bearer ${{ secrets.CRON_SECRET }}" \
             ${{ vars.NEXT_PUBLIC_APP_URL }}/api/cron/release-reviews
 
+      - name: Expire pending bookings
+        run: |
+          curl --fail -s -X GET \
+            -H "Authorization: Bearer ${{ secrets.CRON_SECRET }}" \
+            ${{ vars.NEXT_PUBLIC_APP_URL }}/api/cron/expire-pending-bookings
+
   daily:
     if: github.event.schedule == '0 13 * * *' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest

--- a/e2e/payments/stripe-connect-gating.spec.ts
+++ b/e2e/payments/stripe-connect-gating.spec.ts
@@ -1,0 +1,143 @@
+import { test, expect, type APIRequestContext } from "@playwright/test";
+
+import { E2E_PASSWORD, E2E_USER_ACTIVE } from "../auth/constants";
+import { login } from "../auth/helpers";
+
+/**
+ * Epic 9 — Stripe Connect gating, JIT acceptance UX.
+ *
+ * Scope: focused JIT-redirect tests against the
+ * `/dashboard/payments/earnings-and-payouts?returnTo=...` endpoint.
+ *
+ * What is covered here (and verifiable end-to-end without Stripe):
+ *   - Entry to JIT mode when the owner is not payout-verified.
+ *   - Server-side auto-redirect back to `returnTo` once the user is verified
+ *     (the 9.1 "round-trip" pivot point — Stripe iframe completion itself is
+ *     simulated via the test-only `/api/test/set-stripe-connect-state` route).
+ *   - Capability regression: a verified user whose payouts are disabled
+ *     re-enters JIT mode rather than being redirected out (9.2).
+ *
+ * Not covered here:
+ *   - Driving the actual Stripe Connect Embedded Components iframe to enter
+ *     SSN/bank. Stripe's hosted UI cannot be reliably automated in Playwright.
+ *   - The `Accept` click on a real pending booking. There are no rental
+ *     fixtures in the E2E seed; the 403→redirect contract is covered by
+ *     route-level integration tests under `src/app/api/rentals/[id]/approve`
+ *     and `src/app/api/services/bookings/[id]/accept`.
+ */
+
+const RETURN_TO_PATH = "/dashboard/rentals";
+const JIT_URL = `/dashboard/payments/earnings-and-payouts?returnTo=${encodeURIComponent(
+  RETURN_TO_PATH,
+)}`;
+const EARNINGS_TABS_LABEL = /Payment methods/i;
+
+type ConnectState = {
+  stripeConnectedAccountId?: string | null;
+  connectChargesEnabled?: boolean;
+  connectPayoutsEnabled?: boolean;
+  connectOnboardingComplete?: boolean;
+};
+
+async function setConnectState(
+  request: APIRequestContext,
+  email: string,
+  state: ConnectState,
+): Promise<void> {
+  const response = await request.post("/api/test/set-stripe-connect-state", {
+    data: { email, ...state },
+  });
+  if (!response.ok()) {
+    throw new Error(
+      `set-stripe-connect-state failed: ${response.status()} ${await response.text()}`,
+    );
+  }
+}
+
+async function clearConnectState(
+  request: APIRequestContext,
+  email: string,
+): Promise<void> {
+  await setConnectState(request, email, {
+    stripeConnectedAccountId: null,
+    connectChargesEnabled: false,
+    connectPayoutsEnabled: false,
+    connectOnboardingComplete: false,
+  });
+}
+
+test.describe("Stripe Connect gating — JIT mode", () => {
+  test.beforeEach(async ({ request }) => {
+    await clearConnectState(request, E2E_USER_ACTIVE);
+  });
+
+  test.afterEach(async ({ request }) => {
+    await clearConnectState(request, E2E_USER_ACTIVE);
+  });
+
+  /**
+   * 9.1 — Happy-path JIT round-trip pivot.
+   *
+   * The user lands on the JIT URL while their cached Connect state is
+   * `not_started`; the page must render the focused JIT view (no PaymentsTabs).
+   * We then simulate completion of Stripe Connect via the test endpoint and
+   * reload — the server must `redirect()` straight back to `returnTo`.
+   */
+  test("redirects a verified user back to returnTo; renders JIT view when not verified", async ({
+    page,
+    request,
+  }) => {
+    await login(page, E2E_USER_ACTIVE, E2E_PASSWORD);
+
+    // not_started → JIT view rendered, no PaymentsTabs.
+    await page.goto(JIT_URL);
+    await expect(page).toHaveURL(/earnings-and-payouts\?returnTo=/);
+    await expect(page.getByText(EARNINGS_TABS_LABEL)).toBeHidden();
+
+    // Simulate Stripe completion — webhook would do this in production.
+    await setConnectState(request, E2E_USER_ACTIVE, {
+      connectChargesEnabled: true,
+      connectPayoutsEnabled: true,
+      connectOnboardingComplete: true,
+    });
+
+    // verified + returnTo → server-side redirect.
+    await page.goto(JIT_URL);
+    await expect(page).toHaveURL(new RegExp(`${RETURN_TO_PATH}$`));
+  });
+
+  /**
+   * 9.2 — Capability-regression path.
+   *
+   * Start the user verified, confirm the JIT URL bounces them out, then flip
+   * `connectPayoutsEnabled = false`. The user is now `restricted`: the JIT URL
+   * must render the JIT view (no auto-redirect) so the renewal flow can run.
+   */
+  test("a previously-verified user whose payouts are disabled re-enters JIT mode", async ({
+    page,
+    request,
+  }) => {
+    await setConnectState(request, E2E_USER_ACTIVE, {
+      connectChargesEnabled: true,
+      connectPayoutsEnabled: true,
+      connectOnboardingComplete: true,
+    });
+    await login(page, E2E_USER_ACTIVE, E2E_PASSWORD);
+
+    // verified → bounce out of JIT.
+    await page.goto(JIT_URL);
+    await expect(page).toHaveURL(new RegExp(`${RETURN_TO_PATH}$`));
+
+    // Regress: payouts disabled but onboardingComplete stays true → restricted.
+    await setConnectState(request, E2E_USER_ACTIVE, {
+      connectChargesEnabled: true,
+      connectPayoutsEnabled: false,
+      connectOnboardingComplete: true,
+    });
+
+    // restricted + returnTo → JIT view rendered, no PaymentsTabs.
+    await page.goto(JIT_URL);
+    await expect(page).toHaveURL(/earnings-and-payouts\?returnTo=/);
+    await expect(page.getByText(EARNINGS_TABS_LABEL)).toBeHidden();
+  });
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -57,6 +57,11 @@ export default defineConfig({
       testMatch: /e2e\/services\/.*\.spec\.ts/,
       use: { ...devices["Desktop Chrome"] },
     },
+    {
+      name: "payments",
+      testMatch: /e2e\/payments\/.*\.spec\.ts/,
+      use: { ...devices["Desktop Chrome"] },
+    },
   ],
   globalSetup: path.resolve(
     process.cwd(),

--- a/specs/stripe-connect-gating/1-requirements.md
+++ b/specs/stripe-connect-gating/1-requirements.md
@@ -1,0 +1,251 @@
+# Stripe Connect Gating — Move From Listing Creation to Booking Acceptance — Requirements Document
+
+## Introduction
+
+Today Hoador requires a fully onboarded Stripe Connect Express account before a user can create a rental or service listing. This gate sits at the wrong place in the funnel: it forces the highest-friction step (KYC, SSN, bank account) before the user has felt any product value, and it suppresses listing supply.
+
+This spec moves the hard Stripe Connect requirement from **listing creation** to **booking acceptance** — the first moment money actually needs to move. Users can create and publish listings without a connected payout account; the requirement is enforced just-in-time when an owner attempts to accept a rental request or a provider attempts to accept a service booking.
+
+This change affects both **rentals** (owner approves renter via `/api/rentals/[id]/approve`) and **services** (provider accepts requester via `/api/services/bookings/[id]/accept`). It does not change the underlying Stripe Connect onboarding component, the `account.updated` webhook, the user schema, or the platform-hold payment lifecycle defined in `specs/payments/phase1`.
+
+### Scope
+
+**In scope:**
+
+- Removing the Stripe Connect onboarding requirement from rental and service listing creation (frontend and service-layer checks).
+- Hard server-side enforcement at the two booking-acceptance endpoints.
+- Just-in-time (JIT) onboarding UX at the acceptance touchpoint, with context preservation across the Stripe onboarding redirect.
+- A derived `payoutReadiness` view on the user (no schema migration).
+- Pending-booking auto-expiry when an owner never completes Stripe.
+- Handling of partial Stripe Connect capability states (e.g. `charges_enabled=true`, `payouts_enabled=false`).
+- Renter-facing messaging when an accept is pending owner onboarding.
+- Analytics events for the new funnel.
+
+**Out of scope:**
+
+- The admin listing-approval workflow (already exists, see `specs/listing-review/`).
+- The in-app Payments UI page (separate, see `specs/payments-page/`).
+- The payment lifecycle (capture, deposit hold, transfer) — see `specs/payments/phase1/`.
+- Stripe Connect account creation and the `account.updated` webhook (already implemented).
+- Multi-currency or non-US payout support (US-only Express remains a platform constraint).
+- Changes to the renter-side customer flow — only the owner/provider payout side is affected.
+
+### Key Architectural Decisions
+
+1. **Booking acceptance is the single hard gate.** All other Stripe Connect checks are advisory/soft prompts. There is no other path through which the platform creates a PaymentIntent or initiates a transfer.
+2. **Listings remain fully discoverable and bookable without Stripe Connect.** Renters and requesters can submit booking requests against any approved listing regardless of the owner's payout status.
+3. **Payout readiness is a derived view, not a new column.** A helper computes `{ stripeConnected, chargesEnabled, payoutsEnabled, onboardingStatus }` from the existing `stripeConnectedAccountId`, `connectChargesEnabled`, `connectPayoutsEnabled`, and `connectOnboardingComplete` columns on the `users` table.
+4. **Acceptance re-checks Stripe live before charging.** Cached DB flags are used to render UI and short-circuit the API, but the canonical check just before any PaymentIntent or transfer call uses a live `stripe.accounts.retrieve()` to catch capability regressions.
+5. **Pending bookings expire if the owner never completes onboarding.** The renter is notified and refunded any pre-authorized amount, and the listing is _not_ automatically taken down.
+
+## Requirements
+
+### Requirement 1: Decouple Listing Creation From Stripe Connect
+
+**User Story:** As a tool owner or service provider, I want to create and publish a listing without first connecting a Stripe payout account, so that I can describe what I'm offering before being asked for sensitive financial information.
+
+#### Acceptance Criteria
+
+1. The system SHALL remove the Stripe Connect onboarding check from the rental listing creation page at `src/app/dashboard/listings/add/page.tsx`.
+2. The system SHALL remove the Stripe Connect onboarding check from the service listing creation page at `src/app/dashboard/services/listings/create/page.tsx`.
+3. The system SHALL remove the `userDAL.isConnectOnboardingComplete()` enforcement from `ListingService` at `src/features/listings/services/listing-service.ts` so that listing creation no longer throws when Stripe Connect is incomplete.
+4. The system SHALL remove the equivalent check from the service listing creation service path.
+5. WHERE a user without a connected Stripe account submits a listing for admin approval THEN the system SHALL accept the submission and route it through the existing admin review flow unchanged.
+6. WHEN an admin approves a listing whose owner has not completed Stripe Connect THEN the system SHALL publish the listing as live and make it discoverable to renters/requesters.
+7. The system SHALL NOT display a Stripe-related error or gating screen at any step of the listing creation flow.
+
+### Requirement 2: Derived Payout Readiness View
+
+**User Story:** As a developer, I want a single canonical helper for "is this user ready to accept bookings", so that downstream code (gating, UI, analytics) makes consistent decisions without each caller assembling its own predicate.
+
+#### Acceptance Criteria
+
+1. The system SHALL expose a server-side helper (e.g. `getPayoutReadiness(user)`) that returns an object of shape `{ stripeConnected: boolean, chargesEnabled: boolean, payoutsEnabled: boolean, onboardingStatus: 'not_started' | 'pending' | 'restricted' | 'verified' }`.
+2. The helper SHALL derive its values from the existing `users` table columns (`stripeConnectedAccountId`, `connectChargesEnabled`, `connectPayoutsEnabled`, `connectOnboardingComplete`) — no schema migration is introduced.
+3. WHERE `stripeConnectedAccountId` is null THEN `onboardingStatus` SHALL be `'not_started'` and `stripeConnected` SHALL be `false`.
+4. WHERE `stripeConnectedAccountId` is set AND `connectOnboardingComplete` is false THEN `onboardingStatus` SHALL be `'pending'`.
+5. WHERE `connectChargesEnabled` and `connectPayoutsEnabled` are both true THEN `onboardingStatus` SHALL be `'verified'`.
+6. WHERE Stripe Connect is partially capable (e.g. `chargesEnabled=true` AND `payoutsEnabled=false`) THEN `onboardingStatus` SHALL be `'restricted'`.
+7. The helper SHALL be the single source of truth used by all gating UI, the JIT onboarding modal, and any analytics events.
+8. The system SHALL NOT add new persisted columns to the user table for this feature.
+
+### Requirement 3: Booking Acceptance Hard Gate — Backend
+
+**User Story:** As the platform, I want booking acceptance to be the single enforced gate for Stripe Connect readiness, so that no listing can take real money from a renter until the owner can actually receive it.
+
+#### Acceptance Criteria
+
+1. WHEN an owner submits a rental approval to `POST /api/rentals/[id]/approve` THEN the system SHALL verify the owner's Stripe Connect readiness before any side effects.
+2. WHEN a provider submits a service booking accept to `POST /api/services/bookings/[id]/accept` THEN the system SHALL verify the provider's Stripe Connect readiness before any side effects.
+3. The system SHALL perform the readiness check in two layers:
+   - **Fast path** — the cached `connectChargesEnabled` AND `connectPayoutsEnabled` columns must both be true.
+   - **Authoritative path** — immediately before creating any PaymentIntent or transfer, the system SHALL call `stripe.accounts.retrieve(stripeConnectedAccountId)` and verify `charges_enabled === true` AND `payouts_enabled === true`.
+4. IF the fast-path check fails THEN the system SHALL return HTTP 403 with body `{ error: 'PAYMENT_SETUP_REQUIRED', onboardingStatus, missingCapabilities }` and SHALL NOT call Stripe further.
+5. IF the authoritative-path check fails (cached flags say ready, live Stripe says not ready) THEN the system SHALL return HTTP 403 with the same error shape, SHALL update the cached flags from the live response, AND SHALL NOT create the PaymentIntent.
+6. WHERE the readiness check fails THEN the system SHALL NOT change the booking's status — the request remains in its prior state (e.g. `pending`) so the owner can retry after completing onboarding.
+7. The system SHALL log a structured event including `userId`, `bookingId`, `bookingType` (`rental` | `service`), and `onboardingStatus` whenever a 403 `PAYMENT_SETUP_REQUIRED` is returned.
+
+### Requirement 4: Booking Acceptance — Just-in-Time Onboarding UX
+
+**User Story:** As an owner with a pending booking, I want to be guided directly into Stripe onboarding from the accept screen and returned to the same booking afterward, so that I do not lose context or have to navigate back manually.
+
+#### Acceptance Criteria
+
+1. WHEN the owner views a pending rental request OR service booking THEN the system SHALL display the accept action regardless of Stripe Connect status.
+2. WHEN the owner clicks Accept AND `getPayoutReadiness(user).onboardingStatus !== 'verified'` THEN the system SHALL open a Just-in-Time onboarding modal instead of submitting the accept request.
+3. The JIT modal SHALL display:
+   - A heading that frames the action positively (e.g. "Connect your payout account to accept this booking"), NOT a Stripe-branded or verification-themed heading.
+   - A short explanation of why payout setup is required (one sentence).
+   - A primary CTA labeled "Connect payout account" (or similar) that initiates the existing `ConnectOnboarding` flow.
+   - A secondary "Not now" / dismiss option that leaves the booking in pending state.
+4. WHEN the owner completes Stripe Connect onboarding from the JIT flow THEN the system SHALL return the user to the original accept context (the same rental or service booking) and not to a generic dashboard.
+5. WHEN the user returns from Stripe onboarding AND the `account.updated` webhook has updated their flags THEN the system SHALL automatically re-present the accept action without requiring a page refresh, or at minimum display a clear "Onboarding complete — accept booking now" CTA.
+6. WHERE the user returns from Stripe onboarding but the `account.updated` webhook has not yet fired THEN the system SHALL still allow them to attempt accept; the server-side authoritative check (Requirement 3.3) is the source of truth.
+7. The system SHALL NOT use any of the following copy in user-facing UI: "Enter your SSN", "Stripe verification required", "KYC", "Tax ID required".
+8. The system SHALL use positively framed copy such as "Get paid for your rentals" or "Connect your bank to accept bookings" wherever a Stripe Connect prompt is shown outside the JIT modal.
+
+### Requirement 5: Pending Booking Auto-Expiry
+
+**User Story:** As a renter/requester, I want a request that sits unaccepted to expire predictably rather than hang forever, so that I know when to look elsewhere and am not left in limbo.
+
+#### Acceptance Criteria
+
+1. The system SHALL define a configurable expiry window for pending booking requests (default: 72 hours from request creation).
+2. WHEN a pending rental request OR service booking has been in `pending` state past the expiry window AND the owner has NOT accepted THEN the system SHALL transition it to `expired`.
+3. WHEN a request expires THEN the system SHALL notify the renter/requester via the existing notification channel with a message indicating the owner did not respond in time.
+4. WHEN a request expires THEN the system SHALL notify the owner that the request expired and (where applicable) include a soft prompt to complete Stripe Connect setup so future requests can be accepted.
+5. WHEN a request expires THEN the system SHALL NOT take down the listing or mark the owner as inactive.
+6. WHERE the owner has Stripe Connect set up but simply did not respond THEN the expiry behavior SHALL be identical — the auto-expiry SHALL NOT discriminate by Connect status.
+7. WHERE the renter/requester has any pre-authorized amount (e.g. a deposit auth hold tied to a future-dated start) THEN the system SHALL release that authorization before sending the expiry notification.
+
+### Requirement 6: Multi-Listing, Single Connect Account
+
+**User Story:** As an owner with multiple listings, I want to onboard once and have all my listings unlock at the same time, so that I don't repeat the payout setup per listing.
+
+#### Acceptance Criteria
+
+1. The system SHALL treat the Stripe Connect account as a property of the user, not of the listing.
+2. WHEN the `account.updated` webhook reports `charges_enabled` and `payouts_enabled` are both true THEN the system SHALL mark the user as `verified` and all their existing listings SHALL become bookable end-to-end without additional setup.
+3. The system SHALL NOT create per-listing Stripe Connect accounts or per-listing onboarding flows.
+
+### Requirement 7: Partial Capability Handling
+
+**User Story:** As the platform, I want to correctly handle Stripe Connect accounts that are partially capable (e.g. can charge but cannot receive payouts), so that funds are never trapped or transferred to an account that cannot receive them.
+
+#### Acceptance Criteria
+
+1. WHERE `payouts_enabled` is false (regardless of `charges_enabled`) THEN the system SHALL block booking acceptance with `onboardingStatus = 'restricted'`.
+2. WHERE `charges_enabled` is false THEN the system SHALL block booking acceptance with `onboardingStatus = 'restricted'`.
+3. The system SHALL re-fetch live Stripe account state at acceptance time (per Requirement 3.3) so that capability regressions (a previously verified account being moved back to `restricted` by Stripe) are detected before any transfer is attempted.
+4. WHEN the live re-check reveals a regression THEN the system SHALL update the cached `connectChargesEnabled`, `connectPayoutsEnabled`, and `connectOnboardingComplete` columns to match the live state.
+5. WHERE `onboardingStatus` is `'restricted'` THEN the JIT onboarding modal SHALL frame the message as "Finish setting up your payout account" (not "Start setup"), and the CTA SHALL deep-link into the user's existing Connect account rather than starting a new one.
+
+### Requirement 8: Soft Prompts Outside the Hard Gate
+
+**User Story:** As a user without a connected payout account, I want gentle, well-timed prompts to set up payouts so I'm ready when a booking comes in, without being blocked from doing anything else.
+
+#### Acceptance Criteria
+
+1. WHERE the user has at least one published listing AND `onboardingStatus !== 'verified'` THEN the system SHALL display a non-blocking banner or card prompt (e.g. in the dashboard) recommending payout setup.
+2. WHEN the user receives their first booking request AND `onboardingStatus !== 'verified'` THEN the system SHALL surface a higher-emphasis prompt on the booking screen.
+3. The system SHALL NOT block any non-payment action (listing edits, messaging, profile updates, viewing requests) based on Stripe Connect status.
+4. WHERE the user is in `pending` or `restricted` status THEN the soft prompt copy SHALL reflect the actual state (e.g. "Finish setting up your payout account" vs. "Connect a payout account").
+
+### Requirement 9: Renter-Facing UX During Owner Onboarding
+
+**User Story:** As a renter/requester whose request is pending, I want to understand what's happening without being exposed to the owner's payment internals, so that the experience feels normal and respectful.
+
+#### Acceptance Criteria
+
+1. The system SHALL NOT expose the owner's Stripe Connect status to the renter/requester.
+2. WHILE a booking request is in `pending` state THEN the renter/requester SHALL see a neutral "Waiting on owner" status — identical regardless of whether the owner has Stripe Connect set up.
+3. WHEN the booking expires per Requirement 5 THEN the renter-facing message SHALL say the owner did not respond in time and SHALL NOT mention payment setup.
+4. The system SHALL allow the renter/requester to cancel a pending request at any time before acceptance with no Stripe-related consequences.
+
+### Requirement 10: Analytics & Observability
+
+**User Story:** As a product owner, I want to measure whether moving the gate to acceptance improves listing creation conversion without hurting overall fulfilled bookings, so that I can validate the decision and detect regressions.
+
+#### Acceptance Criteria
+
+1. The system SHALL emit a `listing_created_without_stripe_connect` event when a user publishes a listing while `onboardingStatus !== 'verified'`.
+2. The system SHALL emit a `connect_onboarding_started_from_accept` event when a user starts Stripe Connect onboarding via the JIT modal.
+3. The system SHALL emit a `connect_onboarding_completed_from_accept` event when a user completes onboarding within the JIT flow and is returned to the acceptance context.
+4. The system SHALL emit an `accept_blocked_payment_setup_required` event whenever the API returns 403 `PAYMENT_SETUP_REQUIRED`.
+5. The system SHALL emit a `pending_booking_expired_owner_not_ready` event when a pending booking auto-expires AND the owner's `onboardingStatus` is not `'verified'` at expiry time.
+6. Each event SHALL include `userId`, `bookingType` (`rental` | `service`) where applicable, `onboardingStatus`, and `listingId` / `bookingId` where applicable.
+
+## Non-Functional Requirements
+
+### Performance
+
+1. The fast-path readiness check SHALL add no more than one indexed column lookup to the existing acceptance request and SHALL NOT increase API latency by more than 10ms p95.
+2. The authoritative live `stripe.accounts.retrieve` call SHALL be performed at most once per acceptance attempt.
+3. The JIT modal SHALL render within 200ms of the user clicking Accept.
+
+### Reliability
+
+1. The authoritative live check SHALL be wrapped in a single retry on transient Stripe API errors (`StripeRateLimitError`, `StripeAPIError`, `StripeConnectionError`).
+2. WHERE the live check cannot be completed after retry THEN the system SHALL fail closed (return 403, do not proceed) rather than fail open.
+3. WHERE the `account.updated` webhook is delayed THEN the live authoritative check SHALL still allow a freshly-onboarded user to accept their booking without waiting for the webhook.
+
+### Security
+
+1. The system SHALL NOT expose another user's Stripe Connect status, account ID, or capability flags through any API response.
+2. The 403 `PAYMENT_SETUP_REQUIRED` response SHALL only be returned to the authenticated owner/provider of the booking — third parties SHALL receive the existing generic 403/404.
+3. The JIT modal flow SHALL NOT pass any sensitive Stripe credentials through the client; the existing server-side onboarding link generation SHALL be reused.
+
+### Usability
+
+1. All Stripe-related copy SHALL use positive, value-framed language (per Requirement 4.7 and 4.8).
+2. The JIT onboarding flow SHALL preserve return context to the originating booking with zero manual navigation by the user.
+3. The dashboard soft prompt SHALL be dismissible per-session but SHALL re-appear on subsequent sessions while readiness is incomplete.
+
+## Assumptions
+
+1. The existing Stripe Connect onboarding component at `src/features/users/components/connect-onboarding.tsx` is suitable for embedding inside the JIT modal flow.
+2. The existing `account.updated` webhook handler at `src/services/stripe/webhook-handlers.ts` accurately reflects `charges_enabled` / `payouts_enabled` into the cached user columns.
+3. The admin listing-review flow (`specs/listing-review/`) does not currently require the owner to have completed Stripe Connect, OR will be updated independently to remove any such requirement.
+4. The payment lifecycle defined in `specs/payments/phase1/` creates the rental PaymentIntent immediately after acceptance — meaning acceptance is the only meaningful enforcement point for Stripe Connect readiness.
+5. Service bookings follow the same "accept = trigger immediate charge" model as rentals; provider readiness must be enforced at the accept step.
+6. Renter/requester customer-side Stripe state (saved payment methods, Stripe Customer ID) is unaffected by this change.
+
+## Constraints
+
+1. Stripe Connect Express accounts remain US-only (existing platform constraint, not changed here).
+2. The existing user schema (`stripeConnectedAccountId`, `connectChargesEnabled`, `connectPayoutsEnabled`, `connectOnboardingComplete`) is not modified — payout readiness is derived from these fields.
+3. The existing `account.updated` webhook contract is not modified.
+4. The existing PaymentIntent and transfer flows (per `specs/payments/phase1/`) are not modified — only the _precondition checks_ leading into them.
+5. The change must work within the Next.js App Router architecture.
+
+## Edge Cases
+
+1. **Owner onboards mid-acceptance** — User clicks Accept → JIT modal → completes onboarding → returns. If the `account.updated` webhook has not yet flipped the cached flags, the authoritative live check (Requirement 3.3) still allows the accept to proceed and updates the flags inline.
+2. **Stripe regresses a verified account** — Cached flags say verified, live retrieve returns `payouts_enabled=false`. The accept is blocked, cached flags are updated, the JIT modal is shown with "Finish setting up your payout account" copy.
+3. **Multiple pending requests on one listing, owner not onboarded** — All requests remain pending until either the owner onboards and accepts each, or the per-request expiry fires individually.
+4. **Owner declines instead of accepting** — Decline does not require Stripe Connect (no money moves on decline). Existing decline flow is unaffected.
+5. **Renter cancels a pending request** — Allowed at any time; no Stripe Connect check applies.
+6. **Owner onboards, then deletes their Connect account** — `account.closed` webhook (already handled) flips cached flags to false; subsequent accepts are blocked with `onboardingStatus = 'restricted'` and the JIT modal prompts re-onboarding.
+7. **User attempts to accept a booking on a listing whose admin approval was revoked** — Existing listing-approval check takes precedence over the Stripe Connect check; user sees the existing listing-status error, not a payout error.
+8. **Webhook arrives out-of-order** — Authoritative live check is the source of truth at accept time; webhook ordering does not affect correctness of the gate.
+9. **Listing created without Stripe, never receives a booking** — No action required. Listing stays live and discoverable; soft prompts continue per Requirement 8.
+10. **Owner has two listings, accepts on one (completing onboarding), then accepts on the other** — Second accept passes the fast-path check (cached flags are now true) and the live re-check; no second onboarding round-trip.
+
+## Out of Scope (Deferred / Separate Specs)
+
+1. **In-app Payments UI** — embedded balance, payouts, payments-list, and documents components (covered by `specs/payments-page/`).
+2. **Payment lifecycle** — manual transfers, deposit auth holds, dispute window (covered by `specs/payments/phase1/`).
+3. **Admin listing-review workflow** — already in place (`specs/listing-review/`).
+4. **Multi-currency support / non-US Connect accounts** — platform constraint.
+5. **Payment method validation pre-booking** — the renter's payment method check at booking-request time is unchanged.
+6. **Email/SMS notification redesign** — uses existing notification infrastructure; copy refresh only.
+
+## Success Criteria
+
+1. Users can complete the full listing creation flow (rental and service) and reach the "live listing" state without ever being shown a Stripe Connect prompt.
+2. No PaymentIntent or transfer is ever created against a Stripe Connect account that does not have `charges_enabled` and `payouts_enabled` both true at the moment of the API call.
+3. An owner can complete Stripe Connect onboarding from the JIT modal and return to the originating booking with zero manual navigation.
+4. A pending booking with an unresponsive owner auto-expires within the configured window and the renter receives a clear notification.
+5. Listing creation conversion (created → published) increases measurably after launch (target metric — exact threshold set during rollout planning).
+6. The rate of `accept_blocked_payment_setup_required` events stays low and decreases week-over-week as users complete JIT onboarding.
+7. No regression in fulfilled-booking rate (accepted → completed) compared to pre-change baseline.

--- a/specs/stripe-connect-gating/2-design.md
+++ b/specs/stripe-connect-gating/2-design.md
@@ -1,0 +1,522 @@
+# Stripe Connect Gating — Design Document
+
+## Overview
+
+This design moves the Stripe Connect requirement from listing creation to booking acceptance, with **two enforcement layers**: a fast cached-flag check that short-circuits the API, and an authoritative live `stripe.accounts.retrieve()` call made immediately before any PaymentIntent or transfer. Users without a connected Stripe account can create, publish, and receive booking requests on listings; the requirement only fires at the accept step. When it fires, the owner is routed to the existing earnings-and-payouts page in a "return-after-onboarding" mode that returns them to the originating booking on completion.
+
+### Design Decisions and Refinements From Requirements
+
+These are choices the user made during the design dialogue. They resolve open questions in `1-requirements.md`:
+
+1. **JIT onboarding form factor: extend the existing earnings-and-payouts page, not a new route.** Req 4 in `1-requirements.md` refers to a "JIT modal." This design resolves that to a `returnTo`-aware mode of the existing page at `/dashboard/payments/earnings-and-payouts` ([page.tsx](src/app/dashboard/payments/earnings-and-payouts/page.tsx)). That page already hosts the embedded onboarding component when the user is not onboarded; we add a `?returnTo=<relative-dashboard-url>` query param that (a) hides tabs and the earnings dashboard chrome, (b) renders accept-context copy, and (c) navigates back to `returnTo` on completion. All references to "JIT modal" or "JIT page" in `1-requirements.md` are reinterpreted as "JIT mode of the earnings-and-payouts page" for purposes of this design.
+2. **Analytics: structured server logs only.** Req 10's events are emitted via the existing logger with a consistent shape. No new analytics vendor is introduced.
+3. **Rollout: atomic deploy in one PR.** No feature flag. The old listing-creation gates and the new acceptance gates ship together. Reversibility is via revert.
+4. **Expiry mechanism: persisted `expiresAt` column.** Both `rentalRequests` and `serviceBookings` get a new `expiresAt` timestamp set at creation time. The expiry cron queries on this column.
+
+### Constraints From Existing System
+
+- US-only Stripe Connect Express accounts; not changed here.
+- Embedded `ConnectAccountOnboarding` already in use at [src/features/payments/components/connect-onboarding.tsx](src/features/payments/components/connect-onboarding.tsx) — reused as-is.
+- The `account.updated` webhook at [src/services/stripe/webhook-handlers.ts:82-93](src/services/stripe/webhook-handlers.ts#L82-L93) keeps cached user flags in sync. This design does not modify the webhook.
+- GitHub Actions cron at [.github/workflows/cron-jobs.yml](.github/workflows/cron-jobs.yml) is the driver — the workflow `curl`s each `/api/cron/*` route with a `CRON_SECRET` bearer token. New cron jobs are added as steps in the existing hourly or daily job and follow the existing `verifyCronSecret()` pattern on the route handler. (`vercel.json` contains one vestigial cron entry; it is not relied on.)
+- `sendNotification()` at [src/features/notifications/utils/send-notification.ts](src/features/notifications/utils/send-notification.ts) handles in-app + email + push in one call.
+
+## Architecture
+
+### High-Level Request Flow
+
+```mermaid
+sequenceDiagram
+  participant Owner
+  participant UI as Accept Dialog
+  participant API as /api/.../approve|accept
+  participant Svc as RentalService / ServiceBookingService
+  participant Helper as getPayoutReadiness + assertConnectReady
+  participant Stripe
+  participant DB
+
+  Owner->>UI: Click Accept
+  UI->>API: POST approve / accept
+
+  API->>Svc: approveRentalRequest / acceptBooking
+  Svc->>Helper: getPayoutReadiness(user)
+  alt Cached flags say not ready
+    Helper-->>Svc: { onboardingStatus: 'pending' | 'restricted' | 'not_started' }
+    Svc-->>API: throw PaymentSetupRequiredError
+    API-->>UI: 403 PAYMENT_SETUP_REQUIRED
+    UI->>Owner: Redirect to /dashboard/payments/earnings-and-payouts?returnTo=...
+  else Cached flags say verified
+    Helper->>Stripe: stripe.accounts.retrieve(accountId)
+    alt Live: charges_enabled & payouts_enabled both true
+      Helper->>DB: (no-op; flags already correct)
+      Helper-->>Svc: { onboardingStatus: 'verified' }
+      Svc->>Stripe: create PaymentIntent, etc. (existing flow)
+      Svc-->>API: success
+    else Live: capability regression
+      Helper->>DB: update connectChargesEnabled/connectPayoutsEnabled
+      Helper-->>Svc: { onboardingStatus: 'restricted' }
+      Svc-->>API: throw PaymentSetupRequiredError
+      API-->>UI: 403 PAYMENT_SETUP_REQUIRED
+    end
+  end
+```
+
+### Module Layout
+
+```
+src/
+├── features/
+│   ├── payments/
+│   │   └── lib/
+│   │       ├── payout-readiness.ts        (NEW — getPayoutReadiness, types)
+│   │       └── assert-connect-ready.ts    (NEW — live re-check helper)
+│   ├── rentals/
+│   │   └── services/
+│   │       └── rental-service.ts          (MODIFIED — call assertConnectReady)
+│   └── services/
+│       └── services/
+│           └── service-booking-service.ts (MODIFIED — call assertConnectReady)
+├── app/
+│   ├── api/
+│   │   └── cron/
+│   │       └── expire-pending-bookings/   (NEW — cron route)
+│   │           └── route.ts
+│   └── dashboard/
+│       ├── payments/
+│       │   └── earnings-and-payouts/
+│       │       └── page.tsx               (MODIFIED — accept returnTo query param)
+│       ├── listings/
+│       │   └── add/page.tsx               (MODIFIED — remove gate)
+│       └── services/
+│           └── listings/
+│               └── create/page.tsx        (MODIFIED — remove gate)
+├── features/
+│   └── listings/
+│       └── services/
+│           └── listing-service.ts         (MODIFIED — remove gate)
+├── db/
+│   └── schemas/
+│       ├── rentals.schema.ts              (MODIFIED — add expiresAt)
+│       └── services.schema.ts             (MODIFIED — add expiresAt)
+└── features/
+    └── payments/
+        └── components/
+            ├── earnings-and-payouts-page-client.tsx  (MODIFIED — returnTo mode)
+            └── payout-readiness-banner.tsx           (NEW — soft prompt)
+```
+
+### Rollout
+
+One PR containing the schema migration, the new helpers, the cron job, the earnings-and-payouts `returnTo` mode, the removed listing-creation gates, and the acceptance enforcement. No feature flag. Verified in staging with a Stripe test account in each state (`not_started`, `pending`, `restricted`, `verified`). Reversibility is `git revert` + roll back migration.
+
+## Components and Interfaces
+
+### 1. `getPayoutReadiness(user)` — derived view
+
+**Location:** `src/features/payments/lib/payout-readiness.ts`
+
+```ts
+export type OnboardingStatus =
+  | "not_started"
+  | "pending"
+  | "restricted"
+  | "verified";
+
+export type PayoutReadiness = {
+  stripeConnected: boolean;
+  chargesEnabled: boolean;
+  payoutsEnabled: boolean;
+  onboardingStatus: OnboardingStatus;
+};
+
+export function getPayoutReadiness(user: {
+  stripeConnectedAccountId: string | null;
+  connectChargesEnabled: boolean;
+  connectPayoutsEnabled: boolean;
+  connectOnboardingComplete: boolean;
+}): PayoutReadiness;
+```
+
+**Logic:**
+
+- `stripeConnectedAccountId === null` → `{ stripeConnected: false, onboardingStatus: 'not_started' }`.
+- Has accountId, both flags true → `onboardingStatus: 'verified'`.
+- Has accountId, both flags false, `connectOnboardingComplete === false` → `onboardingStatus: 'pending'`.
+- Has accountId, partial capability (one flag true, one false) OR `connectOnboardingComplete === true` but a flag is false → `onboardingStatus: 'restricted'`.
+
+**Callers:** UI gating (accept dialog, soft-prompt banner), the JIT onboarding page (to choose copy variant), `assertConnectReady` (for fast-path short-circuit), logging events.
+
+### 2. `assertConnectReady(userId, opts)` — authoritative gate
+
+**Location:** `src/features/payments/lib/assert-connect-ready.ts`
+
+```ts
+export type AssertConnectReadyOptions = {
+  /** Booking type for log context. */
+  bookingType: "rental" | "service";
+  /** Booking ID for log context. */
+  bookingId: string;
+  /** Stripe SDK client (injected for testability). */
+  stripe: Stripe;
+};
+
+export async function assertConnectReady(
+  userId: string,
+  opts: AssertConnectReadyOptions,
+): Promise<void>;
+```
+
+**Behavior:**
+
+1. Load the user's cached flags via `userDAL.findById(userId)`.
+2. Compute `readiness = getPayoutReadiness(user)`.
+3. If `readiness.onboardingStatus !== 'verified'` → emit `accept_blocked_payment_setup_required` log event and throw `PaymentSetupRequiredError({ onboardingStatus, missingCapabilities })`. No Stripe call.
+4. Otherwise, call `stripe.accounts.retrieve(user.stripeConnectedAccountId)` with one retry on `StripeRateLimitError` / `StripeAPIError` / `StripeConnectionError` (1-second backoff).
+5. If `account.charges_enabled` AND `account.payouts_enabled` both true → return; no flag update needed.
+6. If regression (either is false) → update `users.connectChargesEnabled`, `users.connectPayoutsEnabled`, recompute `connectOnboardingComplete`, emit `accept_blocked_payment_setup_required` log event with `{ regression: true }`, throw `PaymentSetupRequiredError`.
+7. If the retrieve call fails after retry → fail closed: throw `PaymentSetupRequiredError({ onboardingStatus: 'unknown', reason: 'stripe_unreachable' })`.
+
+**Why this shape:** Combining the cached-flag fast path and the live re-check in one helper means the two service paths (`RentalService`, `ServiceBookingService`) call exactly one function, in exactly one place, with no opportunity to skip the live check.
+
+### 3. `PaymentSetupRequiredError` — typed error
+
+**Location:** `src/features/payments/lib/errors.ts`
+
+```ts
+export class PaymentSetupRequiredError extends Error {
+  readonly code = "PAYMENT_SETUP_REQUIRED";
+  constructor(
+    public details: {
+      onboardingStatus: OnboardingStatus | "unknown";
+      missingCapabilities?: ("charges" | "payouts")[];
+      reason?: "stripe_unreachable";
+    },
+  ) {
+    super("Payment setup required");
+  }
+}
+```
+
+The two API route handlers translate this into:
+
+```
+HTTP 403
+{
+  "error": "PAYMENT_SETUP_REQUIRED",
+  "onboardingStatus": "pending",
+  "missingCapabilities": ["payouts"]
+}
+```
+
+### 4. Modified `RentalService.approveRentalRequest`
+
+**Location:** `src/features/rentals/services/rental-service.ts`
+
+Replace the existing `userDAL.isConnectOnboardingComplete()` block at lines 416-423 with a single call:
+
+```ts
+await assertConnectReady(rentalRequest.ownerId, {
+  bookingType: "rental",
+  bookingId: rentalRequest.id,
+  stripe,
+});
+```
+
+This is the only Stripe Connect check on this code path. All downstream PaymentIntent creation continues to assume readiness.
+
+### 5. Modified `ServiceBookingService.acceptBooking`
+
+**Location:** `src/features/services/services/service-booking-service.ts`
+
+Replace the existing `assertProviderConnectForCharge(providerId)` call at lines 297-303 with:
+
+```ts
+await assertConnectReady(providerId, {
+  bookingType: "service",
+  bookingId: bookingId,
+  stripe,
+});
+```
+
+`assertProviderConnectForCharge` can be deleted as part of this change (its callers were limited to this one path).
+
+### 6. Listing-creation gate removal
+
+Three sites delete the existing Stripe Connect precondition:
+
+- [src/app/dashboard/listings/add/page.tsx:21-50](src/app/dashboard/listings/add/page.tsx#L21-L50) — remove the readiness check and the error-state UI; render the listing form unconditionally for authenticated users.
+- [src/app/dashboard/services/listings/create/page.tsx:35-59](src/app/dashboard/services/listings/create/page.tsx#L35-L59) — same.
+- [src/features/listings/services/listing-service.ts:164-177](src/features/listings/services/listing-service.ts#L164-L177) — remove `userDAL.isConnectOnboardingComplete()` precondition. Service listing creation has an equivalent block to remove.
+
+### 7. JIT Mode on the Existing Earnings-and-Payouts Page
+
+**Location:** [src/app/dashboard/payments/earnings-and-payouts/page.tsx](src/app/dashboard/payments/earnings-and-payouts/page.tsx) (server component) + [src/features/payments/components/earnings-and-payouts-page-client.tsx](src/features/payments/components/earnings-and-payouts-page-client.tsx) (client island).
+
+**Route:** existing — `/dashboard/payments/earnings-and-payouts?returnTo=<relative-dashboard-url>`
+
+**Why extend instead of create a new route:** The existing page is already where users connect their Stripe account. When not onboarded, it renders `<InitiateStripeOnboarding />`; when onboarded, it renders `<OwnerSection />` plus tabs and an explainer. A parallel route would duplicate this logic and risk drift. We add a `returnTo` query param that adjusts the page's behavior while keeping a single source of truth for the onboarding entry point.
+
+**Behavior changes on the page:**
+
+1. Server component reads the `returnTo` query param. Validates it:
+   - Must start with `/dashboard/` (regex: `/^\/dashboard\/[^/].*/` to reject `//evil.com`-style schemes).
+   - Absolute URLs and protocol-relative URLs rejected (prevents open-redirect).
+   - If invalid or missing, the page renders in its current behavior (no JIT mode).
+2. Computes `readiness = getPayoutReadiness(user)` and passes both `returnTo` and `readiness` to the client component.
+3. **When `returnTo` is set:**
+   - Hide the `<PaymentsTabs />` chrome, `<OwnerSection />`, and `<PaymentExplainerSection />`.
+   - Render only the onboarding component (`<InitiateStripeOnboarding />` / `<ConnectOnboarding />`) with accept-context copy varying by `readiness.onboardingStatus`:
+     - `not_started` → "Connect your payout account to accept this booking"
+     - `pending` → "Finish connecting your payout account"
+     - `restricted` → "Your payout account needs more information"
+     - `verified` → `router.replace(returnTo)` immediately (someone followed a stale link)
+   - On onboarding completion (the existing `/api/stripe/update-onboarding-status` callback succeeds), `router.push(returnTo)` instead of switching to `<OwnerSection />`.
+4. **When `returnTo` is not set:** Page renders exactly as it does today — no behavioral change.
+
+**Why a page-level mode, not a modal:** `ConnectAccountOnboarding` is tall (Stripe's hosted flow renders dozens of form fields and KYC sub-screens). A modal can clip content and breaks on mobile. Full-page rendering sidesteps both issues, and the existing page already handles the embedded layout correctly.
+
+**Copy never uses:** "SSN", "KYC", "verification", "tax ID". Only "payout account", "get paid", "connect your bank".
+
+### 8. Accept dialog — error handling and redirect
+
+**Location:** `src/features/rentals/components/renting-lending/approve-request-dialog.tsx` and the equivalent service-booking accept component.
+
+**Change:** On `403 PAYMENT_SETUP_REQUIRED` from the accept API:
+
+- Suppress the generic error toast.
+- Navigate to `/dashboard/payments/earnings-and-payouts?returnTo=<current-booking-url>`.
+- The booking remains in `pending` state (the server did not transition it).
+
+No pre-flight check is added on the client. We always attempt the accept and react to the 403 — this is simpler, races-safe (cache could be stale either way), and means the JIT redirect is driven by the authoritative server check, not by a possibly-stale client view.
+
+### 9. Soft-prompt banner
+
+**Location:** `src/components/payments/payout-readiness-banner.tsx`
+
+**Where it renders:** As a dismissible banner inside the dashboard layout, visible on all `/dashboard/*` routes where the current user has at least one published listing AND `onboardingStatus !== 'verified'`.
+
+**Dismissal:** Per-session (sessionStorage key `payout-readiness-banner-dismissed`). Resets on next session while readiness remains incomplete.
+
+**Copy variants** (matching `onboardingStatus`):
+
+- `not_started` → "Connect your payout account so you can accept bookings the moment a request comes in." CTA: "Connect now"
+- `pending` → "Finish setting up your payout account to accept bookings." CTA: "Finish setup"
+- `restricted` → "Your payout account needs an update. Bookings can't be accepted until this is fixed." CTA: "Update now"
+
+All CTAs link to `/dashboard/payments/earnings-and-payouts` (no `returnTo` — the soft prompt is dashboard-level, not booking-specific; after onboarding the user lands on the normal earnings dashboard).
+
+### 10. Pending-booking expiry cron
+
+**Location:** `src/app/api/cron/expire-pending-bookings/route.ts`
+
+**Schedule:** Hourly. Added as a new step in the `hourly` job of [.github/workflows/cron-jobs.yml](.github/workflows/cron-jobs.yml), alongside the existing `monitor-deposit-expiry`, `detect-stale-processing`, and `release-reviews` steps. No changes to `vercel.json`. The workflow `curl`s the new route with the existing `CRON_SECRET` bearer.
+
+**Why hourly:** The pending-booking expiry window is 72 hours, so the cron's own precision past ~1 hour is invisible to users. Hourly fits the existing batch (no new workflow needed), keeps renter notifications fresh (within an hour of actual expiry), and is cheap to run.
+
+**Logic per tick:**
+
+1. Verify `CRON_SECRET` via existing `verifyCronSecret()`.
+2. Query both tables for rows where `status = 'pending'` AND `expiresAt < NOW()`.
+3. For each rental request:
+   - Update `status = 'cancelled'`, `cancelledAt = NOW()`, with a `cancellationReason = 'expired_no_acceptance'` (new enum value or string).
+   - Release any pre-authorized deposit hold (per existing payment lifecycle).
+   - `sendNotification()` to renter ("The owner did not respond in time").
+   - `sendNotification()` to owner — if `getPayoutReadiness(owner).onboardingStatus !== 'verified'`, copy includes a soft prompt to complete payout setup; otherwise generic "request expired" copy.
+   - Emit log event `pending_booking_expired_owner_not_ready` (with `ownerOnboardingStatus`).
+4. For each service booking: same flow, using `serviceBookings` table and the matching status fields.
+
+**Idempotency:** Each row is updated in a single transaction guarded by `WHERE status = 'pending'` — concurrent ticks cannot double-expire.
+
+**Failure behavior:** Per-row try/catch; one bad row does not stop the batch. Failures emit `pending_booking_expiry_failed` log events and surface in operations alerts (existing pattern from `monitor-deposit-expiry`).
+
+### 11. Structured logging
+
+**Location:** A thin wrapper in `src/features/payments/lib/log-events.ts` over the existing logger.
+
+```ts
+type GatingEvent =
+  | "listing_created_without_stripe_connect"
+  | "connect_onboarding_started_from_accept"
+  | "connect_onboarding_completed_from_accept"
+  | "accept_blocked_payment_setup_required"
+  | "pending_booking_expired_owner_not_ready";
+
+export function logGatingEvent(
+  event: GatingEvent,
+  props: {
+    userId: string;
+    bookingType?: "rental" | "service";
+    bookingId?: string;
+    listingId?: string;
+    onboardingStatus?: OnboardingStatus | "unknown";
+    [key: string]: unknown;
+  },
+): void;
+```
+
+Emit sites:
+
+- `listing_created_without_stripe_connect` → `ListingService.createListing` (and service equivalent), after successful creation when `onboardingStatus !== 'verified'`.
+- `connect_onboarding_started_from_accept` → earnings-and-payouts page mount when `returnTo` is set.
+- `connect_onboarding_completed_from_accept` → onboarding completion callback when `returnTo` was set, after `update-onboarding-status` returns.
+- `accept_blocked_payment_setup_required` → inside `assertConnectReady` when it throws.
+- `pending_booking_expired_owner_not_ready` → cron, after each expiry.
+
+Log shape is the same as existing logger entries (JSON, server-side). Searchable via existing log infra.
+
+## Data Models
+
+### New columns
+
+**`rentalRequests.expiresAt`** — `timestamptz NOT NULL`
+
+**`serviceBookings.expiresAt`** — `timestamptz NOT NULL`
+
+### Default value at row creation
+
+Both insert sites add `expiresAt = createdAt + interval '72 hours'`. The window is centralized in a constant `PENDING_BOOKING_EXPIRY_WINDOW_HOURS = 72` in `src/constants/payments.ts`. Changing the window in future is a one-line change.
+
+### Migration
+
+```sql
+ALTER TABLE rental_requests
+  ADD COLUMN expires_at timestamptz;
+
+UPDATE rental_requests
+  SET expires_at = created_at + interval '72 hours'
+  WHERE expires_at IS NULL;
+
+ALTER TABLE rental_requests
+  ALTER COLUMN expires_at SET NOT NULL;
+
+CREATE INDEX rental_requests_status_expires_at_idx
+  ON rental_requests (status, expires_at)
+  WHERE status = 'pending';
+
+-- Same three statements for service_bookings.
+```
+
+Partial index on `status = 'pending'` keeps the cron query indexed without inflating index size for terminal-state rows.
+
+### `cancellationReason`
+
+If the existing schema does not already have a `cancellationReason` field, add `cancellationReason text` (nullable) to both tables. Used to distinguish expiry-driven cancellation from user-initiated cancellation in the renter notification and in analytics queries. If a field already exists, reuse it.
+
+### No user table changes
+
+The user table is not modified. Payout readiness is fully derived from `stripeConnectedAccountId`, `connectChargesEnabled`, `connectPayoutsEnabled`, `connectOnboardingComplete`.
+
+## Error Handling
+
+### API error contract
+
+The accept endpoints (`POST /api/rentals/[id]/approve`, `POST /api/services/bookings/[id]/accept`) translate `PaymentSetupRequiredError` into:
+
+```
+HTTP 403
+Content-Type: application/json
+
+{
+  "error": "PAYMENT_SETUP_REQUIRED",
+  "onboardingStatus": "pending" | "restricted" | "not_started" | "unknown",
+  "missingCapabilities": ["charges" | "payouts"]
+}
+```
+
+Only the authenticated booking owner/provider receives this body. Third parties receive the existing 403/404.
+
+### Client error handling
+
+Accept-dialog components branch on `error.code === 'PAYMENT_SETUP_REQUIRED'`:
+
+- Do not show a generic error toast.
+- Navigate to `/dashboard/payments/earnings-and-payouts?returnTo=<current-booking-url>`.
+- Booking remains pending; the user can retry from the same URL after onboarding.
+
+All other error codes flow through the existing error UX.
+
+### Live Stripe call failure
+
+`stripe.accounts.retrieve` failures are wrapped in one retry on transient error classes (rate-limit, API, connection). After retry, failure is treated as fail-closed: a `PaymentSetupRequiredError({ onboardingStatus: 'unknown', reason: 'stripe_unreachable' })` is thrown. The owner is routed to the earnings-and-payouts page (in `returnTo` mode), which on `unknown` shows generic "Connect issue — please retry shortly" copy and a manual retry button. The booking remains pending.
+
+### Webhook delay (owner just finished onboarding)
+
+If the user returns to the booking before `account.updated` has flipped cached flags:
+
+- Cached flag check fails fast.
+- `assertConnectReady` does not call Stripe (it short-circuits on cached flags being false).
+- This is the wrong answer — the user has actually onboarded.
+
+**Mitigation:** The earnings-and-payouts page's onboarding completion callback writes the updated capabilities directly to the user row before navigating back, via the existing `/api/stripe/update-onboarding-status` endpoint. The user returns to the booking with cached flags already correct. The `account.updated` webhook arrives later and is idempotent.
+
+### Capability regression (cached says ready, live says not)
+
+Caught by the live re-check. Cached flags are updated to match live; the booking remains pending; the user is routed to the earnings-and-payouts page (in `returnTo` mode) with `restricted` copy.
+
+### Cron job failure
+
+Per-row try/catch keeps the batch alive on bad rows. Failed rows emit `pending_booking_expiry_failed` log events. The next cron tick picks them up again. Permanent failures (a row that fails 10+ ticks) trip an ops alert via the same channel used by `monitor-deposit-expiry`.
+
+### Deposit auth hold release on expiry
+
+If the renter has a pre-authorized deposit on a pending booking (only possible if the booking was approved before then re-entering pending — edge case), the expiry cron must release the authorization before transitioning state. Use the existing `stripe.paymentIntents.cancel` path documented in `specs/payments/phase1/`.
+
+## Testing Strategy
+
+### Unit tests
+
+- `getPayoutReadiness` — table-driven test covering all four `onboardingStatus` branches and the partial-capability cases.
+- `assertConnectReady`:
+  - Cached flags fail → throws without calling Stripe (verify Stripe client not called).
+  - Cached flags pass, live OK → resolves; no DB write.
+  - Cached flags pass, live regression → updates DB, throws.
+  - Stripe transient error → retried once, then throws `PaymentSetupRequiredError` with `reason: 'stripe_unreachable'`.
+  - Stripe non-transient error → throws immediately (no retry).
+- Expiry cron job logic:
+  - Picks up only `pending` rows with `expiresAt < NOW()`.
+  - Idempotent under concurrent ticks (use `pg_advisory_lock` or `SELECT ... FOR UPDATE SKIP LOCKED` in test fixtures).
+  - Continues batch on single-row failure.
+
+### Integration tests
+
+- `POST /api/rentals/[id]/approve` happy path: owner with `verified` status → 200, booking transitions to `approved`, log event `accept_succeeded` (existing).
+- Same endpoint with owner in each non-`verified` state → 403 `PAYMENT_SETUP_REQUIRED` with correct `onboardingStatus` in body; booking stays `pending`.
+- `POST /api/services/bookings/[id]/accept` — same matrix.
+- Listing creation with non-`verified` user → 200, listing created, `listing_created_without_stripe_connect` log event emitted.
+- Cron route `POST /api/cron/expire-pending-bookings`:
+  - With valid `CRON_SECRET` and seeded expired rows → rows transition to `cancelled`, notifications sent (mock `sendNotification`).
+  - With invalid secret → 401.
+
+### End-to-end tests
+
+One scripted Playwright flow (Stripe test mode):
+
+1. New user signs up, no Stripe Connect.
+2. Creates rental listing → published successfully.
+3. Second test user submits booking request against the listing.
+4. First user clicks Accept → redirected to `/dashboard/payments/earnings-and-payouts?returnTo=...`.
+5. Completes Stripe Connect onboarding (using Stripe test mode + test SSN/bank).
+6. Auto-redirected back to the booking, clicks Accept → succeeds, PaymentIntent created.
+
+A second E2E variant simulates the regression path by using Stripe CLI to manually reject capabilities post-onboarding.
+
+### Manual UAT
+
+- Soft-prompt banner appears on dashboard for non-`verified` users with published listings; dismisses for the session; reappears next session.
+- Earnings-and-payouts page in `returnTo` mode renders correctly on mobile (chrome hidden, onboarding component visible).
+- Earnings-and-payouts page with no `returnTo` query param renders unchanged from current behavior.
+- `returnTo` open-redirect protection: `?returnTo=https://evil.com`, `?returnTo=//evil.com`, and `?returnTo=/login` all reject and the page falls back to its default (non-JIT) rendering.
+- Capability-regression path: manually set `connectPayoutsEnabled = false` in DB on a verified account, click Accept → user is routed to the earnings-and-payouts page with `restricted` copy.
+
+### Non-functional verification
+
+- Latency budget: time `POST /api/rentals/[id]/approve` p95 in staging with `assertConnectReady` enabled; confirm <10ms regression on fast-path (cached-flag fail) and <800ms on slow-path (live Stripe call).
+- Failure-mode coverage: with Stripe set to error mode (Stripe CLI), confirm accept returns 403 `stripe_unreachable` and booking remains pending — not silently advanced.
+
+---
+
+Does the design look good? If so, we can move on to the task list. Worth flagging:
+
+- I left `cancellationReason` as "add if not present" — happy to inspect the existing schema and pin that down if you want.
+- The `returnTo` open-redirect protection is conservative (relative `/dashboard/...` URLs only). If you need it to accept other paths, tell me which.
+- I left the soft-prompt banner placement at "inside dashboard layout, all `/dashboard/*` routes." If you want it scoped tighter (only home / only the requests list), say so.

--- a/specs/stripe-connect-gating/3-tasks.md
+++ b/specs/stripe-connect-gating/3-tasks.md
@@ -1,0 +1,172 @@
+# Stripe Connect Gating — Implementation Tasks
+
+Ordered for incremental builds: each section's tasks build on the prior section's. Requirement references point to [1-requirements.md](1-requirements.md). Design references point to sections in [2-design.md](2-design.md).
+
+---
+
+- [x] **1. Foundation: types, errors, log helper**
+  - [x] 1.1 Add `OnboardingStatus` type and `PayoutReadiness` type
+    - File: `src/features/payments/lib/payout-readiness.ts`
+    - Export `OnboardingStatus = 'not_started' | 'pending' | 'restricted' | 'verified'`
+    - Export `PayoutReadiness` shape per design §Components #1
+    - _Requirements: 2.1_
+  - [x] 1.2 Implement `getPayoutReadiness(user)` helper with unit tests
+    - Pure function over the four existing user columns
+    - Unit tests cover all branches: `not_started` (no accountId), `pending` (accountId, both flags false), `verified` (both flags true), `restricted` (partial capability)
+    - _Requirements: 2.1, 2.3, 2.4, 2.5, 2.6, 2.7, 7.1, 7.2_
+  - [x] 1.3 Create `PaymentSetupRequiredError` typed error class
+    - File: `src/features/payments/lib/errors.ts`
+    - Shape per design §Components #3 — includes `code`, `onboardingStatus`, `missingCapabilities`, optional `reason: 'stripe_unreachable'`
+    - _Requirements: 3.4, 3.5_
+  - [x] 1.4 Create `logGatingEvent(event, props)` helper
+    - File: `src/features/payments/lib/log-events.ts`
+    - Wraps the existing server logger with a typed event-name union
+    - Unit test: confirm structured shape is emitted for each event name
+    - _Requirements: 10.1, 10.2, 10.3, 10.4, 10.5, 10.6_
+
+- [x] **2. Data model: expiresAt and cancellationReason**
+  - [x] 2.1 Schema migration: add `expiresAt` to `rentalRequests`
+    - File: `src/db/schemas/rentals.schema.ts` + matching migration file
+    - Add `expires_at timestamptz NOT NULL` column
+    - Backfill existing rows: `expires_at = created_at + interval '72 hours'`
+    - Partial index on `(status, expires_at) WHERE status = 'pending'`
+    - _Requirements: 5.1, 5.2_
+  - [x] 2.2 Schema migration: add `expiresAt` to `serviceBookings`
+    - File: `src/db/schemas/services.schema.ts` + matching migration file
+    - Same shape as 2.1
+    - _Requirements: 5.1, 5.2_
+  - [x] 2.3 Schema migration: add `cancellationReason` if not already present
+    - Inspect both tables first. If absent, add `cancellation_reason text` nullable to each
+    - _Requirements: 5.2, 5.3, 9.3_
+  - [x] 2.4 Add `PENDING_BOOKING_EXPIRY_WINDOW_HOURS = 72` constant
+    - File: `src/constants/payments.ts`
+    - _Requirements: 5.1_
+  - [x] 2.5 Update rental request insert site to set `expiresAt`
+    - Wherever `rentalRequests` rows are created, set `expiresAt = createdAt + PENDING_BOOKING_EXPIRY_WINDOW_HOURS hours`
+    - _Requirements: 5.1_
+  - [x] 2.6 Update service booking insert site to set `expiresAt`
+    - Same as 2.5 for `serviceBookings`
+    - _Requirements: 5.1_
+
+- [x] **3. Backend acceptance gate**
+  - [x] 3.1 Implement `assertConnectReady(userId, opts)` helper with unit tests
+    - File: `src/features/payments/lib/assert-connect-ready.ts`
+    - Behavior per design §Components #2: cached fast-path → live retrieve with one retry → DB sync on regression → fail-closed on Stripe unreachable
+    - Unit tests cover all five branches (cached fails, cached passes & live OK, cached passes & live regresses, transient Stripe error then success, transient Stripe error then failure)
+    - Emits `accept_blocked_payment_setup_required` log event on throw
+    - _Requirements: 3.1, 3.2, 3.3, 3.4, 3.5, 3.7, 7.3, 7.4, 10.4, NFR Reliability 1, 2_
+  - [x] 3.2 Wire `assertConnectReady` into `RentalService.approveRentalRequest`
+    - File: `src/features/rentals/services/rental-service.ts`
+    - Replace the existing `userDAL.isConnectOnboardingComplete()` block (lines 416-423)
+    - Booking state SHALL NOT change when the helper throws
+    - _Requirements: 3.1, 3.6_
+  - [x] 3.3 Wire `assertConnectReady` into `ServiceBookingService.acceptBooking`
+    - File: `src/features/services/services/service-booking-service.ts`
+    - Replace the existing `assertProviderConnectForCharge` call (lines 297-303); delete that function if it has no other callers
+    - _Requirements: 3.2, 3.6_
+  - [x] 3.4 Translate `PaymentSetupRequiredError` → HTTP 403 in both route handlers
+    - Files: `src/app/api/rentals/[id]/approve/route.ts`, `src/app/api/services/bookings/[id]/accept/route.ts`
+    - Response shape per design §Error Handling
+    - _Requirements: 3.4, 3.5, NFR Security 2_
+  - [x] 3.5 Integration tests for both accept endpoints across readiness states
+    - Verified user → 200 + booking transitions
+    - Each of `not_started`, `pending`, `restricted`, regressed-from-verified → 403 `PAYMENT_SETUP_REQUIRED` with correct body, booking stays `pending`
+    - Stripe unreachable → 403 with `reason: 'stripe_unreachable'`, booking stays `pending`
+
+- [x] **4. Remove listing-creation gates**
+  - [x] 4.1 Remove Stripe Connect gate from rental listing creation
+    - Files: `src/app/dashboard/listings/add/page.tsx` (lines 21-50), `src/features/listings/services/listing-service.ts` (lines 164-177)
+    - Listing form renders unconditionally for authenticated users; service-layer no longer throws on incomplete Connect
+    - _Requirements: 1.1, 1.3, 1.5, 1.6, 1.7_
+  - [x] 4.2 Remove Stripe Connect gate from service listing creation
+    - Files: `src/app/dashboard/services/listings/create/page.tsx` (lines 35-59), service-layer equivalent of the rental check
+    - _Requirements: 1.2, 1.4, 1.5, 1.6, 1.7_
+  - [x] 4.3 Emit `listing_created_without_stripe_connect` log event
+    - In both listing-creation service paths, after a successful insert when `getPayoutReadiness(user).onboardingStatus !== 'verified'`
+    - _Requirements: 10.1_
+
+- [x] **5. Frontend acceptance flow — 403 → redirect**
+  - [x] 5.1 Update rental approve dialog to handle 403 `PAYMENT_SETUP_REQUIRED`
+    - File: `src/features/rentals/components/renting-lending/approve-request-dialog.tsx`
+    - Branch on `error.code`; suppress generic error toast; `router.push('/dashboard/payments/earnings-and-payouts?returnTo=' + currentBookingUrl)`
+    - _Requirements: 4.1, 4.2_
+  - [x] 5.2 Locate and update service-booking accept component for same 403 handling
+    - Identify the component that calls `POST /api/services/bookings/[id]/accept` and apply the same redirect logic
+    - _Requirements: 4.1, 4.2_
+
+- [x] **6. JIT mode on earnings-and-payouts page**
+  - [x] 6.1 Read and validate `returnTo` query param in server component
+    - File: `src/app/dashboard/payments/earnings-and-payouts/page.tsx`
+    - Regex: `/^\/dashboard\/[^/].*/` — reject absolute URLs, protocol-relative URLs, and non-dashboard paths
+    - Pass `returnTo` + computed `readiness` to the client component
+    - _Requirements: 4.4, NFR Security 3_
+  - [x] 6.2 Add `returnTo` mode to client component
+    - File: `src/features/payments/components/earnings-and-payouts-page-client.tsx`
+    - When `returnTo` set: hide `<PaymentsTabs />`, `<OwnerSection />`, `<PaymentExplainerSection />`; render only the onboarding component with copy by `onboardingStatus`
+    - On verified state with `returnTo` set: `router.replace(returnTo)` immediately
+    - On onboarding completion when `returnTo` set: `router.push(returnTo)` instead of switching to `<OwnerSection />`
+    - Apply approved copy per design §Components #7 — no "SSN", "KYC", "verification", "tax ID"
+    - _Requirements: 4.3, 4.4, 4.5, 4.6, 4.7, 4.8, 7.5_
+  - [x] 6.3 Emit `connect_onboarding_started_from_accept` and `connect_onboarding_completed_from_accept` log events
+    - At mount when `returnTo` is set, and at successful onboarding completion when `returnTo` is set
+    - _Requirements: 10.2, 10.3_
+  - [x] 6.4 Unit tests for `returnTo` validation
+    - `?returnTo=https://evil.com` → rejected, page renders in non-JIT mode
+    - `?returnTo=//evil.com` → rejected
+    - `?returnTo=/login` → rejected (not under `/dashboard/`)
+    - `?returnTo=/dashboard/rentals/abc` → accepted
+
+- [x] **7. Soft-prompt banner**
+  - [x] 7.1 Implement `PayoutReadinessBanner` component
+    - File: `src/features/payments/components/payout-readiness-banner.tsx`
+    - Visible when user has at least one published listing AND `onboardingStatus !== 'verified'`
+    - Copy by status per design §Components #9
+    - Session-scoped dismissal (`sessionStorage` key `payout-readiness-banner-dismissed`)
+    - CTA links to `/dashboard/payments/earnings-and-payouts` (no `returnTo`)
+    - _Requirements: 8.1, 8.2, 8.4_
+  - [x] 7.2 Wire banner into dashboard layout
+    - Render inside the dashboard layout so it appears on all `/dashboard/*` routes
+    - _Requirements: 8.1_
+
+- [x] **8. Pending-booking expiry cron**
+  - [x] 8.1 Implement cron route handler
+    - File: `src/app/api/cron/expire-pending-bookings/route.ts`
+    - Use existing `verifyCronSecret()` for auth
+    - Logic per design §Components #10: query both tables for `status='pending' AND expiresAt < NOW()`, transition to `cancelled` with `cancellationReason='expired_no_acceptance'`, release any pre-auth deposit hold, send notifications, emit log event
+    - Per-row try/catch; one bad row does not stop the batch
+    - _Requirements: 5.2, 5.3, 5.4, 5.5, 5.7, 10.5_
+  - [x] 8.2 Unit tests for the cron handler
+    - Picks up only `status='pending'` rows past `expiresAt`
+    - Per-row failure isolation (one throws, others still process)
+    - Notification copy varies based on owner's `onboardingStatus`
+    - Deposit pre-auth release path
+    - _Requirements: 5.2, 5.3, 5.4, 5.7_
+  - [x] 8.3 Add cron step to GitHub Actions workflow
+    - File: `.github/workflows/cron-jobs.yml`
+    - Add a new step in the `hourly` job, alongside `monitor-deposit-expiry`
+    - Uses the existing `${{ secrets.CRON_SECRET }}` / `${{ vars.NEXT_PUBLIC_APP_URL }}` pattern
+    - _Requirements: 5.2_
+
+- [x] **9. End-to-end coverage** _(focused JIT-redirect scope — see notes below)_
+  - [x] 9.1 Playwright happy-path: list → request → accept → JIT onboard → return → accept
+    - **Shipped scope:** `e2e/payments/stripe-connect-gating.spec.ts` covers the JIT pivot end-to-end. Not-verified user lands on `/dashboard/payments/earnings-and-payouts?returnTo=...` → JIT view renders (PaymentsTabs absent); then the test-only `/api/test/set-stripe-connect-state` simulates a Stripe completion → server-side `redirect(returnTo)` is exercised on reload.
+    - **Deferred:** automating the Stripe Connect Embedded Components iframe (SSN/bank entry) and clicking real Accept buttons. No rental fixtures exist in `src/db/seeds/e2e.seed.ts`; the 403→redirect contract is covered by route-level integration tests under `src/app/api/rentals/[id]/approve` and `src/app/api/services/bookings/[id]/accept`.
+    - _Requirements: Success Criteria 1, 2, 3_
+  - [x] 9.2 Playwright capability-regression path
+    - **Shipped scope:** same spec file. Seeds verified state via the test endpoint → JIT URL bounces out → flip `connectPayoutsEnabled = false` → JIT URL renders the JIT view (no redirect), verifying the `restricted` branch.
+    - _Requirements: 7.3, 7.4, 7.5_
+
+---
+
+## Coverage map (requirements → tasks)
+
+- **R1** Decouple listing creation → 4.1, 4.2
+- **R2** Payout readiness view → 1.1, 1.2
+- **R3** Backend hard gate → 3.1, 3.2, 3.3, 3.4, 3.5
+- **R4** JIT onboarding UX → 5.1, 5.2, 6.1, 6.2, 6.3
+- **R5** Pending booking expiry → 2.1, 2.2, 2.4, 8.1, 8.2, 8.3
+- **R6** Multi-listing single account → covered structurally by R3 (no per-listing state introduced)
+- **R7** Partial capability → 1.2, 3.1, 9.2
+- **R8** Soft prompts → 7.1, 7.2
+- **R9** Renter-facing UX → 8.1 (notification copy)
+- **R10** Analytics events → 1.4, 3.1, 4.3, 6.3, 8.1

--- a/specs/stripe-connect-gating/4-uat-test-plan.md
+++ b/specs/stripe-connect-gating/4-uat-test-plan.md
@@ -1,0 +1,589 @@
+# Stripe Connect Gating — User Acceptance Test (UAT) Plan
+
+Hoador • Internal Specification
+
+Pairs with [1-requirements.md](1-requirements.md), [2-design.md](2-design.md), [3-tasks.md](3-tasks.md), [HANDOFF.md](HANDOFF.md).
+
+---
+
+## 1. Introduction
+
+This document defines hands-on UAT scenarios for the Stripe Connect gating rework: the requirement to onboard a payout account has moved from listing creation to booking acceptance. Scenarios are written to be executed on **local dev** against **Stripe test mode**, switching between two pre-existing test accounts ("Owner" and "Renter"). Backend-only checks (cron, log events, migration) use copy-paste `curl` / SQL.
+
+- **Scope:** All work in Epics 1–9 of [3-tasks.md](3-tasks.md): listing-creation decoupling, derived payout readiness, hard backend gate, JIT onboarding UX, `returnTo` validation, capability-regression handling, soft-prompt banner, pending-booking expiry cron, structured logging, and migration 0062 (`expires_at` + cancellation columns).
+- **How to use:** Execute each scenario in order within a section. Tick Pass/Fail. Sections are _roughly_ independent, but **§4 once-only** (real Stripe Connect onboarding) is a one-way operation — re-running prior "not verified" scenarios against the same Owner afterwards will fail.
+
+---
+
+## 2. Traceability — Epics → UAT IDs
+
+| Epic / Task in [3-tasks.md](3-tasks.md) | UAT scenarios                        |
+| --------------------------------------- | ------------------------------------ |
+| 1. Foundation (readiness types, errors) | UAT-SCG-08, 09, 13, 14 (indirect)    |
+| 2. Data model (`expiresAt`, reason)     | UAT-SCG-20, 21                       |
+| 3. Backend acceptance gate              | UAT-SCG-16, 17, 18                   |
+| 4. Listing creation without Connect     | UAT-SCG-01, 02                       |
+| 5. Frontend pre-check + 403 safety net  | UAT-SCG-08, 13 (pre-check); 16 (403) |
+| 6. JIT mode on earnings-and-payouts     | UAT-SCG-09–12, 14–16, 22, 23         |
+| 7. Soft-prompt banner                   | UAT-SCG-03–06                        |
+| 8. Pending-booking expiry cron          | UAT-SCG-19–21                        |
+| 9. E2E coverage                         | Covered indirectly by every section  |
+| Logging (`logGatingEvent`)              | UAT-SCG-24                           |
+
+---
+
+## 3. Test Environment
+
+### 3.1 App
+
+```bash
+bun run dev
+```
+
+The app must be running on `http://localhost:3000` (or wherever your `.env.local` points). Server logs (pino JSON) must be visible in your terminal — you'll grep them in §6.
+
+### 3.2 Required env (`.env.local`)
+
+- `STRIPE_SECRET_KEY` — Stripe test-mode secret
+- `STRIPE_WEBHOOK_SECRET` — for `account.updated` (needed to mark Connect verified)
+- `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` — Stripe test-mode publishable
+- `CRON_SECRET` — required for §5 cron tests
+- `DATABASE_URL` — points at your dev DB; you'll run a handful of `psql` snippets
+
+### 3.3 Stripe webhook listener (required for Connect to flip verified)
+
+In a second terminal:
+
+```bash
+stripe listen --forward-to localhost:3000/api/stripe/webhooks
+```
+
+Keep this running for the duration of UAT — without it, completing Stripe onboarding will not flip your user to `verified`.
+
+### 3.4 Stripe Connect test inputs (memorize for §4)
+
+| Field          | Test value                         |
+| -------------- | ---------------------------------- |
+| SSN            | `000-00-0000`                      |
+| DOB            | Any past date making you ≥18       |
+| Phone          | Any valid-looking US phone         |
+| Address        | Any US address                     |
+| Routing number | `110000000`                        |
+| Account number | `000123456789`                     |
+| Verification   | Stripe auto-approves test accounts |
+
+### 3.5 Test accounts
+
+| Label  | Role in scenarios             | Preconditions                                                                                                    |
+| ------ | ----------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| Owner  | Lists items, accepts requests | Active in the same community as Renter. **Must start with no Stripe Connect account** (clear in §3.7 if needed). |
+| Renter | Submits booking requests      | Active in the same community as Owner. Has at least one saved payment method in `/dashboard/payments`.           |
+
+### 3.6 Migration sanity (one-time)
+
+Run `bun run db:migrate` if you haven't already. Then verify:
+
+```sql
+-- expires_at column exists on both tables and is NOT NULL:
+SELECT column_name, is_nullable
+FROM information_schema.columns
+WHERE table_name IN ('rental_requests', 'service_bookings')
+  AND column_name IN ('expires_at', 'cancellation_reason', 'cancelled_at');
+
+-- partial indexes exist:
+SELECT indexname FROM pg_indexes
+WHERE indexname IN (
+  'rental_requests_pending_expires_at_idx',
+  'sb_pending_expires_at_idx'
+);
+
+-- 'expired_no_acceptance' is in the cancellation_reason enum:
+SELECT unnest(enum_range(NULL::cancellation_reason));
+```
+
+Expected: both columns present (`expires_at NOT NULL`, `cancellation_reason` nullable), both indexes returned, enum includes `expired_no_acceptance`.
+
+### 3.7 Resetting Owner's Connect state between runs (DB)
+
+If you need to "undo" Connect setup mid-UAT (rare — only if you finished onboarding and want to redo `not_started` scenarios), connect to your dev DB and run:
+
+```sql
+UPDATE "user"
+SET
+  stripe_connected_account_id = NULL,
+  connect_charges_enabled = false,
+  connect_payouts_enabled = false,
+  connect_onboarding_complete = false
+WHERE email = '<owner-email>';
+```
+
+Note: this leaves the orphaned Stripe Connect account on Stripe's side. Optional cleanup: delete it from your Stripe test-mode dashboard.
+
+---
+
+## 4. Scenarios
+
+> Convention: Owner and Renter are logged out at the start of each scenario unless noted. "Click Accept" refers to the primary accept button on the booking detail UI.
+
+### §4.1 — Listing creation without Connect (Epic 4)
+
+#### UAT-SCG-01: Owner creates a rental listing without Stripe Connect
+
+- **Actor:** Owner
+- **Preconditions:** Owner has no Stripe Connect account (verify via §3.7 SQL: all four columns null/false).
+- **Steps:**
+  1. Log in as Owner.
+  2. Go to `/dashboard/listings/add`.
+  3. Fill out a rental listing (category, name, description, daily rate, security deposit, etc.) and submit.
+- **Expected:**
+  - The page renders the form without redirecting to a "Set up payouts first" prompt.
+  - The submit succeeds; the listing appears in the Owner's listings list (`pending_review` is fine).
+  - Terminal log line includes `"event":"listing_created_without_stripe_connect"` with the Owner's userId and listingId.
+- [x] Pass / [ ] Fail
+
+#### UAT-SCG-02: Owner creates a service listing without Stripe Connect
+
+- **Actor:** Owner
+- **Preconditions:** Same as 01.
+- **Steps:**
+  1. Log in as Owner.
+  2. Go to `/dashboard/services/listings/create`.
+  3. Fill out a service listing and submit.
+- **Expected:**
+  - Form renders, no Connect gate, listing is created.
+  - Terminal log includes `"event":"listing_created_without_stripe_connect"` with `bookingType` absent and the new service listing's id.
+- [x] Pass / [ ] Fail
+
+### §4.2 — Soft-prompt banner (Epic 7)
+
+#### UAT-SCG-03: Banner appears on dashboard when Owner has a published listing and is `not_started`
+
+- **Actor:** Owner
+- **Preconditions:** UAT-SCG-01 done; the listing must be `approved` and `is_active = true` (the banner uses the same definition as "active listing"). If your dev seed doesn't auto-approve, log in as Admin and approve the listing, **or** run:
+
+  ```sql
+  UPDATE listings
+  SET approval_status = 'approved', status = 'available', is_active = true
+  WHERE owner_id = (SELECT id FROM "user" WHERE email = '<owner-email>')
+    AND name = '<listing-name>';
+  ```
+
+- **Steps:**
+  1. Log in as Owner. Visit `/dashboard`.
+- **Expected:**
+  - A yellow/amber banner is visible above the dashboard content.
+  - Copy: "Connect your payout account so you can accept bookings the moment a request comes in."
+  - CTA button "Connect now" links to `/dashboard/payments/earnings-and-payouts` (no `returnTo` in the URL).
+- [x] Pass / [ ] Fail
+
+#### UAT-SCG-04: Banner dismissal is session-scoped
+
+- **Actor:** Owner
+- **Preconditions:** UAT-SCG-03 passing.
+- **Steps:**
+  1. On `/dashboard`, click the banner's dismiss (×) button.
+  2. Navigate to another dashboard page (e.g. `/dashboard/listings`).
+  3. Refresh the tab (`Cmd+R`).
+  4. Close the tab and open a fresh tab (or new private window), log in again, visit `/dashboard`.
+- **Expected:**
+  - After step 1: banner disappears immediately.
+  - Step 2: banner still hidden.
+  - Step 3: banner still hidden (same session).
+  - Step 4: banner reappears (new session).
+- [x] Pass / [ ] Fail
+
+#### UAT-SCG-05: Banner hidden when Owner has no published listings
+
+- **Actor:** Owner
+- **Preconditions:** Owner has no `approved`+`available`/`rented` listings (you can flip one to inactive via DB: `UPDATE listings SET is_active = false WHERE ...`).
+- **Steps:**
+  1. Visit `/dashboard`.
+- **Expected:** No banner shown.
+- [x] Pass / [ ] Fail
+
+#### UAT-SCG-06: Banner copy reflects `pending` state mid-onboarding
+
+- **Actor:** Owner
+- **Preconditions:** UAT-SCG-03 listing visible. To simulate `pending` state (i.e. Stripe account exists but `chargesEnabled`/`payoutsEnabled` are still false):
+
+  ```sql
+  UPDATE "user"
+  SET stripe_connected_account_id = 'acct_uat_dummy',
+      connect_charges_enabled = false,
+      connect_payouts_enabled = false,
+      connect_onboarding_complete = false
+  WHERE email = '<owner-email>';
+  ```
+
+- **Steps:**
+  1. Reload `/dashboard` (open a new session if you dismissed in 04).
+- **Expected:**
+  - Banner copy: "Finish setting up your payout account to accept bookings."
+  - CTA label: "Finish setup".
+- **Cleanup:** revert to `not_started` via §3.7 SQL before continuing.
+- [x] Pass / [ ] Fail
+
+### §4.3 — Backend gate + frontend redirect, rentals (Epics 3, 5)
+
+#### UAT-SCG-07: Renter submits a rental request to Owner
+
+- **Actor:** Renter
+- **Preconditions:** UAT-SCG-01 listing is approved and visible in the community.
+- **Steps:**
+  1. Log in as Renter.
+  2. Browse to the Owner's listing.
+  3. Submit a rental request with valid dates (start within 48h is fine) and a saved payment method.
+- **Expected:**
+  - Request submitted; appears in Renter's "Renting" list as `pending`.
+  - DB check (optional):
+
+    ```sql
+    SELECT id, status, expires_at,
+           expires_at - created_at AS lifetime
+    FROM rental_requests
+    WHERE renter_id = (SELECT id FROM "user" WHERE email = '<renter-email>')
+    ORDER BY created_at DESC LIMIT 1;
+    ```
+
+    `expires_at` is set, `lifetime` ≈ 72 hours.
+
+- [x] Pass / [ ] Fail
+
+#### UAT-SCG-08: Owner clicks Accept while not Connect-verified → pre-check modal → JIT mode
+
+- **Actor:** Owner
+- **Preconditions:** UAT-SCG-07 request exists; Owner is still `not_started`.
+- **Steps:**
+  1. Log in as Owner.
+  2. Open the rental request detail page (under `/dashboard/rental/...` or via the request in "Lending").
+  3. Click Accept.
+  4. In the modal that opens, verify the copy, then click the primary CTA.
+- **Expected:**
+  - **No** generic error toast appears.
+  - Step 3 opens the **Payout Setup Required** modal — it does **not** open the normal Approve Request modal and does **not** immediately navigate.
+    - Title: **"Connect your payout account"**
+    - Description: "Before you can accept this booking, connect a payout account so we can pay you when the renter is charged."
+    - Primary CTA label: **"Connect now"**. Secondary label: **"Not now"**.
+  - Clicking **Not now** closes the modal and leaves the user on the rental request page; status stays `pending`.
+  - Clicking **Connect now** navigates the browser to `/dashboard/payments/earnings-and-payouts?returnTo=<the rental request URL>` (verify the URL bar).
+  - The rental request status is **still** `pending` either way (no state change despite the click) — verify in DB or by reloading the request page.
+  - Terminal logs do **not** include `"event":"accept_blocked_payment_setup_required"` for this click — the pre-check intercepts before any API call. That log line is reserved for the 403 safety-net path exercised in §4.6 (UAT-SCG-16).
+- [x] Pass / [ ] Fail
+
+### §4.4 — JIT mode rendering and Stripe Connect completion (Epic 6) — **one-way operation**
+
+> ⚠️ Once you complete Stripe Connect onboarding in UAT-SCG-11, the Owner is permanently `verified` for this UAT session. To re-run §4.1–§4.3 against this Owner, run the §3.7 reset SQL first.
+
+#### UAT-SCG-09: JIT page hides normal payments chrome and uses contextual copy
+
+- **Actor:** Owner
+- **Preconditions:** Continuing from UAT-SCG-08 (on the JIT URL).
+- **Steps:**
+  1. Inspect the page rendered at `/dashboard/payments/earnings-and-payouts?returnTo=...`.
+- **Expected:**
+  - The "Payment methods" / "Earnings & payouts" tab bar (`PaymentsTabs`) is **not** visible.
+  - The owner-section earnings dashboard and the payment explainer section are **not** visible.
+  - The Stripe Connect onboarding card is the dominant element; heading reads **"Connect your payout account to accept this booking"** (note: this is `not_started` copy — for `restricted`, see UAT-SCG-16).
+  - Description, tips list ("Select Individual", "SSN + DOB are required", "Use a bank account in your name"), and the embedded Stripe Connect Onboarding component are present.
+  - Terminal log: `"event":"connect_onboarding_started_from_accept"` with the Owner's `onboardingStatus: "not_started"`.
+- [x] Pass / [ ] Fail
+
+#### UAT-SCG-10: `returnTo` validation rejects unsafe values
+
+- **Actor:** Owner
+- **Preconditions:** Logged in as Owner; doesn't matter what their Connect state is.
+- **Steps:** Visit each URL in turn (try in incognito or after dismissing earlier banners) and observe behavior:
+  1. `/dashboard/payments/earnings-and-payouts?returnTo=https://evil.example.com`
+  2. `/dashboard/payments/earnings-and-payouts?returnTo=//evil.example.com`
+  3. `/dashboard/payments/earnings-and-payouts?returnTo=/login`
+  4. `/dashboard/payments/earnings-and-payouts?returnTo=/dashboard/rental/abc`
+- **Expected:**
+  - URLs 1–3 render the **normal** earnings page (with `PaymentsTabs` visible) — `returnTo` was rejected, no JIT mode.
+  - URL 4 renders **JIT mode** (no tabs) — accepted.
+- [x] Pass / [ ] Fail
+
+#### UAT-SCG-11: Complete real Stripe Connect onboarding and auto-return to the booking
+
+- **Actor:** Owner
+- **Preconditions:** UAT-SCG-09 passing; webhook listener (`stripe listen`) is running (§3.3).
+- **Steps:**
+  1. From the JIT page, work through the embedded Stripe Connect Onboarding component using the test values from §3.4. Choose "Individual", use any plausible name matching the SSN `000-00-0000`.
+  2. Submit. The component will indicate completion (Stripe auto-approves test accounts).
+  3. Watch your terminals:
+     - App server: `"event":"connect_onboarding_completed_from_accept"` log line.
+     - Stripe CLI: `account.updated` webhook delivered with `200`.
+  4. After completion the page should navigate to `returnTo` (the original rental request).
+  5. On the rental request page, click Accept again.
+- **Expected:**
+  - Step 3: both log lines appear.
+  - Step 4: you land back on the rental request page (no manual navigation needed).
+  - Step 5: the request transitions to `approved` (Accept succeeded). Renter sees the change in their "Renting" view.
+- [x] Pass / [ ] Fail
+
+#### UAT-SCG-12: Verified Owner visiting a JIT URL is bounced to `returnTo` automatically
+
+- **Actor:** Owner (now `verified` from 11)
+- **Preconditions:** Owner is `verified`.
+- **Steps:**
+  1. Visit `/dashboard/payments/earnings-and-payouts?returnTo=/dashboard/rentals` directly.
+- **Expected:**
+  - The server responds with a redirect; you land on `/dashboard/rentals` without ever seeing JIT content.
+- [x] Pass / [ ] Fail
+
+### §4.5 — Services parity (Epics 3, 5, 6 — service path)
+
+> If you haven't completed the rental flow yet, services scenarios can be done with the _same_ Owner if you reset Connect state via §3.7. Otherwise, the service-side gate is structurally identical; spot-check the redirect and skip a full repeat.
+
+#### UAT-SCG-13: Renter submits a service booking; Provider clicks Accept while not verified → pre-check modal → JIT mode
+
+- **Actor:** Renter, then Owner (acting as service Provider)
+- **Preconditions:** Owner is `not_started` (run §3.7 reset SQL if needed); the service listing from UAT-SCG-02 is approved.
+- **Steps:**
+  1. As Renter, request a booking on the service listing.
+  2. As Owner, open the booking detail (`/dashboard/services/bookings/<id>`) and click Accept.
+  3. In the modal that opens, verify the copy, then click the primary CTA.
+- **Expected:**
+  - Step 2 opens the **Payout Setup Required** modal (same shared component as UAT-SCG-08) — it does **not** open the normal Accept Booking modal and does **not** immediately navigate.
+    - Title: **"Connect your payout account"**, CTA **"Connect now"**, secondary **"Not now"**.
+  - **Not now** closes the modal; booking stays `pending`.
+  - **Connect now** navigates to `/dashboard/payments/earnings-and-payouts?returnTo=/dashboard/services/bookings/<id>`.
+  - No error toast at any step.
+  - Booking status remains `pending` either way.
+  - Terminal logs do **not** include `"event":"accept_blocked_payment_setup_required"` for this click — pre-check intercepts before any API call. (The server-side log fires only when the 403 safety net activates — see UAT-SCG-16.)
+- [x] Pass / [ ] Fail
+
+#### UAT-SCG-14: JIT completion auto-returns to the service booking
+
+- **Actor:** Owner
+- **Preconditions:** Continuing from 13.
+- **Steps:**
+  1. Complete Connect onboarding inside the JIT view (or if Owner is already verified from 11, skip directly).
+  2. After auto-return, click Accept on the service booking.
+- **Expected:**
+  - Booking transitions to `accepted`; Renter sees the change.
+- [x] Pass / [ ] Fail
+
+### §4.6 — Capability regression (Epics 1, 6, 7)
+
+#### UAT-SCG-15: Cached-flag regression — verified Owner whose `connect_payouts_enabled` flips false in DB
+
+- **Actor:** Owner (already `verified`)
+- **Preconditions:** A new pending rental request from Renter (resubmit one) and Owner is currently `verified`.
+- **Steps:**
+  1. Simulate Stripe regression in the DB:
+
+     ```sql
+     UPDATE "user"
+     SET connect_payouts_enabled = false
+     WHERE email = '<owner-email>';
+     ```
+
+  2. Log in as Owner and visit `/dashboard`. (The banner check.)
+  3. Open the pending rental request and click Accept.
+  4. In the modal that opens, inspect the copy, then click the primary CTA.
+  5. On the JIT page, inspect the heading.
+
+- **Expected:**
+  - Step 2: dashboard banner copy "Your payout account needs an update. Bookings can't be accepted until this is fixed." CTA "Update now".
+  - Step 3: the **Payout Setup Required** modal opens (pre-check catches the stale cached flag).
+    - Modal title: **"Your payout account needs an update"**
+    - Description: "Your payout account is missing information. Update it so this booking can be accepted and you can get paid."
+    - Primary CTA: **"Update now"**. No toast.
+  - Step 4: clicking **Update now** navigates to `/dashboard/payments/earnings-and-payouts?returnTo=<rental request URL>`.
+  - Step 5: JIT heading reads **"Your payout account needs more information"** (the `restricted` copy).
+  - No `"event":"accept_blocked_payment_setup_required"` log line for this click — pre-check intercepted, no API call. The server-side log is exercised by UAT-SCG-16, where cached flags still say verified.
+- **Cleanup:** restore with `UPDATE "user" SET connect_payouts_enabled = true WHERE email = '<owner-email>';`.
+- [x] Pass / [ ] Fail
+
+#### UAT-SCG-16: `assertConnectReady` catches live capability regression even when cached flags say verified
+
+- **Actor:** Owner
+- **Preconditions:** Owner is fully verified in your dev DB **but** their Stripe Connect account in the dashboard has had a payouts requirement reintroduced (or use the Stripe Dashboard to disable payouts on the test account). If that's hard to reproduce, run:
+
+  ```sql
+  -- Force a "stale cached verified, live restricted" state:
+  UPDATE "user"
+  SET connect_charges_enabled = true,
+      connect_payouts_enabled = true,
+      connect_onboarding_complete = true
+  WHERE email = '<owner-email>';
+  -- Then disable payouts capability in Stripe test dashboard for acct_...
+  ```
+
+  > This is the one path where the 403 safety net (not the pre-check modal) is exercised — the cached flags say verified, so the pre-check sees nothing wrong and lets the normal Approve flow open. Only the server's live `stripe.accounts.retrieve` catches the regression.
+
+- **Steps:**
+  1. Have Renter submit a fresh rental request.
+  2. As Owner, click Accept. The normal Approve Request modal opens (not the pre-check modal — cached flags say verified).
+  3. Click **Approve & Charge Payment** inside that modal to send the request.
+- **Expected:**
+  - The server returns 403 `PAYMENT_SETUP_REQUIRED`; the client's 403 handler redirects to JIT mode with `restricted` copy. **No toast.**
+  - The user's DB row is updated to reflect the regression (`connect_payouts_enabled = false`) — verify in DB after the click.
+  - Log line: `"event":"accept_blocked_payment_setup_required"` with `onboardingStatus: "restricted"` and the regression marker.
+- [x] Pass / [ ] Fail
+
+### §4.7 — Negative path: server unreachable
+
+#### UAT-SCG-17: Stripe-unreachable failure mode
+
+- **Actor:** Owner
+- **Preconditions:** Hard to reproduce without manipulating network. **Optional / skip in normal UAT.** If you want to exercise it, temporarily set `STRIPE_SECRET_KEY` to an invalid value, restart the dev server, then click Accept while cached flags say verified.
+- **Expected:**
+  - Accept returns 403 with `reason: "stripe_unreachable"` in the response body (visible in browser devtools Network tab).
+  - User redirected to JIT mode.
+- [ ] Pass / [ ] Fail / [ ] Skipped
+
+### §4.8 — Pending-booking expiry cron (Epic 8)
+
+#### UAT-SCG-18: Cron endpoint requires CRON_SECRET
+
+- **Actor:** Tester (curl)
+- **Steps:**
+  1. `curl -s -o /dev/null -w "%{http_code}\n" http://localhost:3000/api/cron/expire-pending-bookings`
+  2. `curl -s -o /dev/null -w "%{http_code}\n" -H "Authorization: Bearer wrong" http://localhost:3000/api/cron/expire-pending-bookings`
+  3. `curl -s -H "Authorization: Bearer $CRON_SECRET" http://localhost:3000/api/cron/expire-pending-bookings | jq .`
+- **Expected:**
+  - Step 1 → `401`.
+  - Step 2 → `401`.
+  - Step 3 → `200` and JSON of shape `{ success: true, rentalsChecked, servicesChecked, expiredCount, failedCount, timestamp }`.
+- [ ] Pass / [ ] Fail
+
+#### UAT-SCG-19: Cron auto-cancels a pending rental whose `expires_at` has passed
+
+- **Actor:** Tester (DB + curl)
+- **Preconditions:** A pending rental request exists between Owner (not verified) and Renter. Use the one from UAT-SCG-07 or submit a fresh one.
+- **Steps:**
+  1. Backdate `expires_at` so the cron picks it up:
+
+     ```sql
+     UPDATE rental_requests
+     SET expires_at = NOW() - interval '1 hour'
+     WHERE id = '<request-id>' AND status = 'pending';
+     ```
+
+  2. Trigger the cron:
+
+     ```bash
+     curl -s -H "Authorization: Bearer $CRON_SECRET" \
+       http://localhost:3000/api/cron/expire-pending-bookings | jq .
+     ```
+
+  3. Re-query the row:
+
+     ```sql
+     SELECT status, cancellation_reason, cancelled_at
+     FROM rental_requests WHERE id = '<request-id>';
+     ```
+
+  4. Log in as Renter, check notifications.
+  5. Log in as Owner, check notifications.
+
+- **Expected:**
+  - Cron response: `expiredCount` ≥ 1.
+  - Row is now `status = 'cancelled'`, `cancellation_reason = 'expired_no_acceptance'`, `cancelled_at` set.
+  - Renter notification copy mentions "the owner did not respond in time" and does **not** mention Stripe/payouts/Connect.
+  - Owner notification copy includes the soft-prompt "Set up your payout account..." and links to `/dashboard/payments/earnings-and-payouts` (because Owner is not verified). When Owner is verified, Owner copy is neutral instead.
+  - Terminal log: `"event":"pending_booking_expired_owner_not_ready"` with `bookingType: "rental"`, the bookingId, and `onboardingStatus` for the Owner.
+- [ ] Pass / [ ] Fail
+
+#### UAT-SCG-20: Cron releases the deposit pre-auth on a pending rental
+
+- **Actor:** Tester
+- **Preconditions:** A pending rental request that had a security deposit > 0 captured. Confirm `security_deposit_auth_id` is non-null:
+
+  ```sql
+  SELECT id, security_deposit_auth_id FROM rental_requests WHERE id = '<request-id>';
+  ```
+
+- **Steps:**
+  1. Backdate `expires_at` and trigger the cron as in UAT-SCG-19.
+  2. Open the corresponding PaymentIntent in your Stripe test dashboard (or `stripe payment_intents retrieve <id>`).
+- **Expected:**
+  - PaymentIntent status is `canceled` (Stripe-side).
+  - App-side row is `cancelled` as in 19.
+  - If deposit release errored for some reason, the row is still expired and a `expire-pending-bookings: deposit hold release failed` error appears in the terminal; `expiredCount` still increments. (This is the per-row resilience contract.)
+- [ ] Pass / [ ] Fail
+
+#### UAT-SCG-21: Cron auto-cancels a pending service booking
+
+- **Actor:** Tester
+- **Preconditions:** A pending service booking (from UAT-SCG-13 or a fresh one) between Owner and Renter.
+- **Steps:** Same shape as UAT-SCG-19 but against `service_bookings`:
+
+  ```sql
+  UPDATE service_bookings SET expires_at = NOW() - interval '1 hour'
+  WHERE id = '<booking-id>' AND status = 'pending';
+  ```
+
+  Then re-run the cron and re-query.
+
+- **Expected:**
+  - Row is `cancelled` with `cancellation_reason = 'expired_no_acceptance'`.
+  - Both parties get notifications; renter copy is neutral; provider copy includes payout prompt iff not verified.
+  - Log line: `"event":"pending_booking_expired_owner_not_ready"` with `bookingType: "service"` (when provider isn't verified).
+- [ ] Pass / [ ] Fail
+
+#### UAT-SCG-22: Cron is idempotent under concurrent ticks
+
+- **Actor:** Tester
+- **Steps:**
+  1. Backdate a pending request as in 19.
+  2. Fire the cron twice in a row:
+
+     ```bash
+     for i in 1 2; do
+       curl -s -H "Authorization: Bearer $CRON_SECRET" \
+         http://localhost:3000/api/cron/expire-pending-bookings | jq .
+     done
+     ```
+
+- **Expected:**
+  - First call: `expiredCount = 1` (for that row).
+  - Second call: `expiredCount = 0` — the `WHERE status='pending'` clause in `markRequestExpired` is the guard.
+  - The row's `cancelled_at` did **not** change on the second run.
+  - No duplicate notifications were sent (check Renter's notification list).
+- [ ] Pass / [ ] Fail
+
+### §4.9 — JIT URL safety (Epic 6)
+
+#### UAT-SCG-23: A JIT URL with an unrecognized `returnTo` falls back to the normal page
+
+- Covered in UAT-SCG-10; this is the same safety contract. Tick here if you ran 10.
+- [ ] Pass / [ ] Fail / [ ] N/A
+
+### §4.10 — Structured logging spot-check (Epic 10 / "Logging" section of design)
+
+#### UAT-SCG-24: Each gating event was observed at least once
+
+In your terminal scrollback (or pipe `bun run dev` through `tee` to a file), confirm you saw lines containing each event below at least once during the prior scenarios:
+
+```
+"event":"listing_created_without_stripe_connect"     <- §4.1
+"event":"accept_blocked_payment_setup_required"      <- §4.6 (UAT-SCG-16 only — the live-regression / 403 safety-net path)
+"event":"connect_onboarding_started_from_accept"     <- §4.4
+"event":"connect_onboarding_completed_from_accept"   <- §4.4 (real Stripe finish)
+"event":"pending_booking_expired_owner_not_ready"    <- §4.8
+```
+
+- **Note:** `accept_blocked_payment_setup_required` is a server-side log emitted by `assertConnectReady` when the API returns 403. The pre-check modal in §4.3 / §4.5 intercepts on the client before any API call, so it does **not** produce this log. Only the cached-flags-say-verified-but-live-says-restricted path in UAT-SCG-16 still hits the server and triggers the event.
+- **Expected:** All five strings present in your run history. If UAT-SCG-16 was skipped, mark `accept_blocked_payment_setup_required` as **N/A** rather than failing this scenario.
+- [ ] Pass / [ ] Fail / [ ] N/A on missing event
+
+---
+
+## 5. Sign-off
+
+| Section                       | Tester | Date | Pass count | Fail count |
+| ----------------------------- | ------ | ---- | ---------- | ---------- |
+| §4.1 Listing creation         |        |      |            |            |
+| §4.2 Banner                   |        |      |            |            |
+| §4.3 Rentals gate + redirect  |        |      |            |            |
+| §4.4 JIT mode (rentals)       |        |      |            |            |
+| §4.5 Services parity          |        |      |            |            |
+| §4.6 Capability regression    |        |      |            |            |
+| §4.7 Negative path (optional) |        |      |            |            |
+| §4.8 Expiry cron              |        |      |            |            |
+| §4.9 returnTo safety          |        |      |            |            |
+| §4.10 Logging                 |        |      |            |            |
+
+**Release blocker rule:** any failure in §4.3, §4.4, §4.6, or §4.8 blocks release. §4.7 is informational. Banner / logging failures are P1 but not blockers.

--- a/src/app/api/cron/expire-pending-bookings/__tests__/route.test.ts
+++ b/src/app/api/cron/expire-pending-bookings/__tests__/route.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const expirePendingBookingsMock = vi.fn();
+const recordRunMock = vi.fn();
+
+vi.mock("@/features/payments/lib/expire-pending-bookings", () => ({
+  expirePendingBookings: (...args: unknown[]) =>
+    expirePendingBookingsMock(...args),
+}));
+
+vi.mock("@/features/admin/services/cron-run-history-service", () => ({
+  CronRunHistoryService: {
+    recordRun: (...args: unknown[]) => recordRunMock(...args),
+  },
+}));
+
+vi.mock("@/lib/api/with-request-logging", () => ({
+  withRequestLogging: (handler: unknown) => handler,
+}));
+
+import { GET } from "../route";
+
+function createCronRequest(secret?: string): NextRequest {
+  const headers = new Headers();
+  if (secret) headers.set("authorization", `Bearer ${secret}`);
+  return new NextRequest(
+    "http://localhost:3000/api/cron/expire-pending-bookings",
+    { method: "GET", headers },
+  );
+}
+
+describe("GET /api/cron/expire-pending-bookings", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.CRON_SECRET = "test-cron-secret";
+    expirePendingBookingsMock.mockResolvedValue({
+      rentalsChecked: 0,
+      servicesChecked: 0,
+      expiredCount: 0,
+      failedCount: 0,
+    });
+    recordRunMock.mockResolvedValue(undefined);
+  });
+
+  it("rejects requests without the CRON_SECRET (401)", async () => {
+    const response = await GET(createCronRequest());
+    expect(response.status).toBe(401);
+    expect(expirePendingBookingsMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects requests with the wrong CRON_SECRET (401)", async () => {
+    const response = await GET(createCronRequest("nope"));
+    expect(response.status).toBe(401);
+  });
+
+  it("invokes the service and returns its counts in the response body", async () => {
+    expirePendingBookingsMock.mockResolvedValue({
+      rentalsChecked: 3,
+      servicesChecked: 2,
+      expiredCount: 4,
+      failedCount: 1,
+    });
+
+    const response = await GET(createCronRequest("test-cron-secret"));
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body).toEqual(
+      expect.objectContaining({
+        success: true,
+        rentalsChecked: 3,
+        servicesChecked: 2,
+        expiredCount: 4,
+        failedCount: 1,
+        timestamp: expect.any(String),
+      }),
+    );
+    expect(recordRunMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        jobName: "expire-pending-bookings",
+        status: "success",
+        recordsEligible: 5,
+        recordsSucceeded: 4,
+        recordsFailed: 1,
+      }),
+    );
+  });
+
+  it("returns 500 and records a failure run when the service throws", async () => {
+    expirePendingBookingsMock.mockRejectedValue(new Error("db down"));
+
+    const response = await GET(createCronRequest("test-cron-secret"));
+    expect(response.status).toBe(500);
+    const body = await response.json();
+    expect(body.success).toBe(false);
+    expect(body.error).toBe("db down");
+    expect(recordRunMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        jobName: "expire-pending-bookings",
+        status: "failure",
+        errorMessage: "db down",
+      }),
+    );
+  });
+});

--- a/src/app/api/cron/expire-pending-bookings/route.ts
+++ b/src/app/api/cron/expire-pending-bookings/route.ts
@@ -1,0 +1,61 @@
+import { NextRequest, NextResponse } from "next/server";
+import { withRequestLogging } from "@/lib/api/with-request-logging";
+import { verifyCronSecret } from "@/lib/api/verify-cron-secret";
+import { expirePendingBookings } from "@/features/payments/lib/expire-pending-bookings";
+import { CronRunHistoryService } from "@/features/admin/services/cron-run-history-service";
+
+const JOB_NAME = "expire-pending-bookings";
+
+/**
+ * Cron job to auto-cancel pending rental requests and service bookings whose
+ * expiresAt has passed.
+ * Schedule: 0 * * * * (hourly)
+ */
+async function getHandler(request: NextRequest) {
+  const auth = verifyCronSecret(request);
+  if (!auth.authorized) return auth.response;
+
+  const startedAt = new Date();
+
+  try {
+    const result = await expirePendingBookings();
+
+    await CronRunHistoryService.recordRun({
+      jobName: JOB_NAME,
+      startedAt,
+      completedAt: new Date(),
+      status: "success",
+      recordsEligible: result.rentalsChecked + result.servicesChecked,
+      recordsSucceeded: result.expiredCount,
+      recordsFailed: result.failedCount,
+    });
+
+    return NextResponse.json({
+      success: true,
+      ...result,
+      timestamp: new Date().toISOString(),
+    });
+  } catch (error) {
+    await CronRunHistoryService.recordRun({
+      jobName: JOB_NAME,
+      startedAt,
+      completedAt: new Date(),
+      status: "failure",
+      errorMessage: error instanceof Error ? error.message : String(error),
+    });
+
+    console.error("Expire pending bookings cron error:", error);
+    return NextResponse.json(
+      {
+        success: false,
+        error: error instanceof Error ? error.message : "Unknown error",
+      },
+      { status: 500 },
+    );
+  }
+}
+
+export const GET = withRequestLogging(
+  getHandler,
+  "GET /api/cron/expire-pending-bookings",
+);

--- a/src/app/api/rentals/[id]/approve/route.test.ts
+++ b/src/app/api/rentals/[id]/approve/route.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { NextRequest } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
+import { PaymentSetupRequiredError } from "@/features/payments/lib/errors";
 
 const mockFetch = vi.fn().mockResolvedValue({ ok: true });
 
@@ -31,6 +32,19 @@ const mockRentalRequest = {
 
 vi.mock("@/lib/api/route-helpers", () => ({
   handleApiError: vi.fn((err: unknown) => {
+    if (err instanceof PaymentSetupRequiredError) {
+      return NextResponse.json(
+        {
+          error: err.code,
+          onboardingStatus: err.details.onboardingStatus,
+          ...(err.details.missingCapabilities && {
+            missingCapabilities: err.details.missingCapabilities,
+          }),
+          ...(err.details.reason && { reason: err.details.reason }),
+        },
+        { status: err.statusCode },
+      );
+    }
     throw err;
   }),
   parseFormData: vi.fn().mockResolvedValue({}),
@@ -60,12 +74,17 @@ vi.mock("@/dal", () => ({
     getOrCreateStripeCustomerId: vi.fn().mockResolvedValue("cus_123"),
     getConnectedAccountId: vi.fn().mockResolvedValue("acct_123"),
     isConnectOnboardingComplete: vi.fn().mockResolvedValue(true),
+    updateConnectOnboardingStatus: vi.fn().mockResolvedValue(undefined),
     getUserById: vi.fn().mockImplementation((id: string) =>
       Promise.resolve({
         id,
         email: `${id}@example.com`,
         firstName: "Test",
         lastName: "User",
+        stripeConnectedAccountId: "acct_123",
+        connectChargesEnabled: true,
+        connectPayoutsEnabled: true,
+        connectOnboardingComplete: true,
       }),
     ),
   },
@@ -128,6 +147,12 @@ vi.mock("@/services/stripe/rental-payments", () => ({
   isRetryablePaymentError: vi.fn().mockReturnValue(false),
 }));
 
+vi.mock("@/services/stripe/connect", () => ({
+  getAccountStatus: vi
+    .fn()
+    .mockResolvedValue({ chargesEnabled: true, payoutsEnabled: true }),
+}));
+
 vi.mock("@/features/rentals/notifications/payment-succeeded", () => ({
   sendPaymentSucceededNotificationToRenter: vi
     .fn()
@@ -139,7 +164,8 @@ vi.mock("@/features/rentals/notifications/rental-approved", () => ({
   sendRentalApprovedNotification: vi.fn().mockResolvedValue(undefined),
 }));
 
-import { rentalDAL } from "@/dal";
+import { rentalDAL, userDAL } from "@/dal";
+import { getAccountStatus } from "@/services/stripe/connect";
 
 describe("POST /api/rentals/[id]/approve", () => {
   const originalFetch = globalThis.fetch;
@@ -193,5 +219,116 @@ describe("POST /api/rentals/[id]/approve", () => {
 
     const body = JSON.parse(mockFetch.mock.calls[0][1].body as string);
     expect(body.rentalRequestId).toBe("req-123");
+  });
+
+  describe("Stripe Connect gating", () => {
+    async function callApprove() {
+      const { POST } = await import("./route");
+      const request = new NextRequest(
+        "http://localhost:3000/api/rentals/req-123/approve",
+        { method: "POST" },
+      );
+      return POST(request, { params: Promise.resolve({ id: "req-123" }) });
+    }
+
+    it("returns 403 PAYMENT_SETUP_REQUIRED when owner has no Stripe Connect account", async () => {
+      vi.mocked(userDAL.getUserById).mockResolvedValueOnce({
+        id: "owner-1",
+        email: "owner-1@example.com",
+        firstName: "Test",
+        lastName: "User",
+        stripeConnectedAccountId: null,
+        connectChargesEnabled: false,
+        connectPayoutsEnabled: false,
+        connectOnboardingComplete: false,
+      } as Awaited<ReturnType<typeof userDAL.getUserById>>);
+
+      const response = await callApprove();
+      expect(response.status).toBe(403);
+      const body = await response.json();
+      expect(body).toEqual({
+        error: "PAYMENT_SETUP_REQUIRED",
+        onboardingStatus: "not_started",
+        missingCapabilities: ["charges", "payouts"],
+      });
+      expect(getAccountStatus).not.toHaveBeenCalled();
+    });
+
+    it("returns 403 with onboardingStatus=pending when account exists but capabilities are off", async () => {
+      vi.mocked(userDAL.getUserById).mockResolvedValueOnce({
+        id: "owner-1",
+        email: "owner-1@example.com",
+        firstName: "Test",
+        lastName: "User",
+        stripeConnectedAccountId: "acct_123",
+        connectChargesEnabled: false,
+        connectPayoutsEnabled: false,
+        connectOnboardingComplete: false,
+      } as Awaited<ReturnType<typeof userDAL.getUserById>>);
+
+      const response = await callApprove();
+      expect(response.status).toBe(403);
+      const body = await response.json();
+      expect(body.error).toBe("PAYMENT_SETUP_REQUIRED");
+      expect(body.onboardingStatus).toBe("pending");
+    });
+
+    it("returns 403 with onboardingStatus=restricted when payouts capability is off", async () => {
+      vi.mocked(userDAL.getUserById).mockResolvedValueOnce({
+        id: "owner-1",
+        email: "owner-1@example.com",
+        firstName: "Test",
+        lastName: "User",
+        stripeConnectedAccountId: "acct_123",
+        connectChargesEnabled: true,
+        connectPayoutsEnabled: false,
+        connectOnboardingComplete: true,
+      } as Awaited<ReturnType<typeof userDAL.getUserById>>);
+
+      const response = await callApprove();
+      expect(response.status).toBe(403);
+      const body = await response.json();
+      expect(body).toEqual({
+        error: "PAYMENT_SETUP_REQUIRED",
+        onboardingStatus: "restricted",
+        missingCapabilities: ["payouts"],
+      });
+    });
+
+    it("returns 403 with regression when cached flags say verified but live shows payouts disabled", async () => {
+      // Default getUserById mock returns verified — so cached fast-path passes.
+      vi.mocked(getAccountStatus).mockResolvedValueOnce({
+        chargesEnabled: true,
+        payoutsEnabled: false,
+      });
+
+      const response = await callApprove();
+      expect(response.status).toBe(403);
+      const body = await response.json();
+      expect(body).toMatchObject({
+        error: "PAYMENT_SETUP_REQUIRED",
+        onboardingStatus: "restricted",
+        missingCapabilities: ["payouts"],
+      });
+      expect(userDAL.updateConnectOnboardingStatus).toHaveBeenCalledWith(
+        "owner-1",
+        { chargesEnabled: true, payoutsEnabled: false },
+      );
+    });
+
+    it("returns 403 with reason=stripe_unreachable when live retrieve fails on non-transient error", async () => {
+      vi.mocked(getAccountStatus).mockRejectedValueOnce(
+        new Error("invalid request"),
+      );
+
+      const response = await callApprove();
+      expect(response.status).toBe(403);
+      const body = await response.json();
+      expect(body).toEqual({
+        error: "PAYMENT_SETUP_REQUIRED",
+        onboardingStatus: "unknown",
+        reason: "stripe_unreachable",
+      });
+    });
   });
 });

--- a/src/app/api/services/listings/route.ts
+++ b/src/app/api/services/listings/route.ts
@@ -112,16 +112,6 @@ async function postHandler(request: NextRequest) {
       { ipAddress, userAgent },
     );
 
-    if (!result.success) {
-      return NextResponse.json(
-        {
-          error: "Stripe Connect must be set up before creating a listing",
-          code: result.error,
-        },
-        { status: 400 },
-      );
-    }
-
     return NextResponse.json({
       listingId: result.listing.id,
       status: result.listing.status,

--- a/src/app/api/stripe/update-onboarding-status/route.ts
+++ b/src/app/api/stripe/update-onboarding-status/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { withRequestLogging } from "@/lib/api/with-request-logging";
 import { tryCatch } from "@walkup/walkup-utils";
 import {
@@ -7,12 +7,18 @@ import {
 } from "@/lib/api/route-helpers";
 import { getAccountStatus } from "@/services/stripe/connect";
 import { userDAL } from "@/dal";
+import { logGatingEvent } from "@/features/payments/lib/log-events";
+import { getPayoutReadiness } from "@/features/payments/lib/payout-readiness";
 
 /**
  * Update onboarding status after completion
  * POST /api/stripe/update-onboarding-status
+ *
+ * Optional body: { fromJitAccept?: boolean } — when true, emits a
+ * `connect_onboarding_completed_from_accept` log event so we can measure JIT
+ * funnel conversion.
  */
-async function postHandler() {
+async function postHandler(request: NextRequest) {
   try {
     // Authenticate
     const authResult = await getAuthenticatedUserResponse();
@@ -20,6 +26,9 @@ async function postHandler() {
       return authResult; // Returns 401
     }
     const { userId } = authResult;
+
+    const body = await request.json().catch(() => ({}));
+    const fromJitAccept = body?.fromJitAccept === true;
 
     // Get connected account ID
     const { data: accountId, error: accountError } = await tryCatch(
@@ -47,6 +56,20 @@ async function postHandler() {
 
     // Update user status in database
     await userDAL.updateConnectOnboardingStatus(userId, status);
+
+    if (fromJitAccept) {
+      const readiness = getPayoutReadiness({
+        stripeConnectedAccountId: accountId,
+        connectChargesEnabled: status.chargesEnabled,
+        connectPayoutsEnabled: status.payoutsEnabled,
+        connectOnboardingComplete:
+          status.chargesEnabled && status.payoutsEnabled,
+      });
+      logGatingEvent("connect_onboarding_completed_from_accept", {
+        userId,
+        onboardingStatus: readiness.onboardingStatus,
+      });
+    }
 
     return NextResponse.json({ success: true });
   } catch (error) {

--- a/src/app/api/test/set-stripe-connect-state/route.ts
+++ b/src/app/api/test/set-stripe-connect-state/route.ts
@@ -1,0 +1,73 @@
+import { NextRequest } from "next/server";
+import { eq } from "drizzle-orm";
+import { db } from "@/db/db";
+import { user as userTable } from "@/db/schemas/user.schema";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * POST /api/test/set-stripe-connect-state
+ *
+ * Test-only route. Returns 404 outside of E2E mode.
+ *
+ * Mutates a user's Stripe Connect cached flags so Playwright can drive the
+ * gating behavior without hitting Stripe. Mirrors what the
+ * `account.updated` webhook would normally do.
+ *
+ * Body (JSON):
+ *   email                       - user email to mutate (required)
+ *   stripeConnectedAccountId    - string | null   (defaults to "acct_e2e_test" when any flag is true)
+ *   connectChargesEnabled       - boolean         (default false)
+ *   connectPayoutsEnabled       - boolean         (default false)
+ *   connectOnboardingComplete   - boolean         (default false)
+ */
+export async function POST(request: NextRequest) {
+  if (process.env.NODE_ENV === "production" || process.env.E2E_TEST !== "1") {
+    return new Response(null, { status: 404 });
+  }
+
+  const body = (await request.json()) as {
+    email?: string;
+    stripeConnectedAccountId?: string | null;
+    connectChargesEnabled?: boolean;
+    connectPayoutsEnabled?: boolean;
+    connectOnboardingComplete?: boolean;
+  };
+
+  if (!body.email) {
+    return Response.json({ error: "email is required" }, { status: 400 });
+  }
+
+  const chargesEnabled = body.connectChargesEnabled ?? false;
+  const payoutsEnabled = body.connectPayoutsEnabled ?? false;
+  const onboardingComplete = body.connectOnboardingComplete ?? false;
+  const anyFlagSet = chargesEnabled || payoutsEnabled || onboardingComplete;
+  const stripeAccountId =
+    body.stripeConnectedAccountId === undefined
+      ? anyFlagSet
+        ? "acct_e2e_test"
+        : null
+      : body.stripeConnectedAccountId;
+
+  const [found] = await db
+    .select({ id: userTable.id })
+    .from(userTable)
+    .where(eq(userTable.email, body.email))
+    .limit(1);
+
+  if (!found) {
+    return Response.json({ error: "user not found" }, { status: 404 });
+  }
+
+  await db
+    .update(userTable)
+    .set({
+      stripeConnectedAccountId: stripeAccountId,
+      connectChargesEnabled: chargesEnabled,
+      connectPayoutsEnabled: payoutsEnabled,
+      connectOnboardingComplete: onboardingComplete,
+    })
+    .where(eq(userTable.id, found.id));
+
+  return Response.json({ success: true });
+}

--- a/src/app/dashboard/(rentals)/(flow)/rentals/[direction]/[status]/page.tsx
+++ b/src/app/dashboard/(rentals)/(flow)/rentals/[direction]/[status]/page.tsx
@@ -1,12 +1,16 @@
 export const dynamic = "force-dynamic";
 import { Suspense } from "react";
 import { notFound } from "next/navigation";
-import { legalDocumentDAL, rentalDAL } from "@/dal";
+import { legalDocumentDAL, rentalDAL, userDAL } from "@/dal";
 import { LEGAL_DOCUMENT_IDS } from "@/constants/legal-documents";
 import { RentalsClient } from "@/features/rentals/components/renting-lending/rentals-client";
 import { getCurrentUserId } from "@/features/auth/utils/session";
 import { getServerQueryClient, HydrateClient } from "@/lib/react-query/server";
 import { rentalKeys } from "@/features/rentals/hooks/use-rentals";
+import {
+  getPayoutReadiness,
+  type OnboardingStatus,
+} from "@/features/payments/lib/payout-readiness";
 
 export const metadata = {
   title: "Rentals",
@@ -213,6 +217,18 @@ export default async function RentalsStatusPage({ params }: RentalsPageProps) {
 
   const [reviewPolicyUrl] = await Promise.all(promises);
 
+  // Only the lending side surfaces an Approve button, so we only need the
+  // current user's payout readiness when they're viewing incoming requests.
+  let ownerOnboardingStatus: OnboardingStatus | undefined;
+  if (userId && initialType === "lending") {
+    try {
+      const currentUser = await userDAL.getUserById(userId);
+      ownerOnboardingStatus = getPayoutReadiness(currentUser).onboardingStatus;
+    } catch {
+      // Non-critical — fall back to the existing 403 redirect path.
+    }
+  }
+
   return (
     <div className="space-y-6">
       <Suspense fallback={<RentalsPageSkeleton />}>
@@ -221,6 +237,7 @@ export default async function RentalsStatusPage({ params }: RentalsPageProps) {
             initialType={initialType}
             initialStatus={initialStatus}
             reviewPolicyUrl={reviewPolicyUrl}
+            ownerOnboardingStatus={ownerOnboardingStatus}
           />
         </HydrateClient>
       </Suspense>

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -5,6 +5,7 @@ import { ConditionalPadding } from "@/components/conditional-padding";
 import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
 import { getCurrentUser } from "@/features/auth/utils/session";
 import { PageHeaderProvider } from "@/contexts/page-header-context";
+import { PayoutReadinessBannerServer } from "@/features/payments/components/payout-readiness-banner-server";
 
 export const dynamic = "force-dynamic";
 
@@ -30,7 +31,10 @@ export default async function DashboardLayout({
         <PageHeaderProvider>
           <SiteHeader />
           <div className="bg-muted/20">
-            <ConditionalPadding>{children}</ConditionalPadding>
+            <ConditionalPadding>
+              <PayoutReadinessBannerServer />
+              {children}
+            </ConditionalPadding>
           </div>
         </PageHeaderProvider>
       </SidebarInset>

--- a/src/app/dashboard/listings/add/page.tsx
+++ b/src/app/dashboard/listings/add/page.tsx
@@ -1,10 +1,8 @@
 export const dynamic = "force-dynamic";
-import Link from "next/link";
-import { listingDAL, legalDocumentDAL, userDAL } from "@/dal";
+import { listingDAL, legalDocumentDAL } from "@/dal";
 import { LEGAL_DOCUMENT_IDS } from "@/constants/legal-documents";
 import { AddListingForm } from "@/features/listings/components/listing-form/add-listing-form";
 import { BackButton } from "@/components/back-button";
-import { Button } from "@/components/ui/button";
 import { getCurrentUserId } from "@/features/auth/utils/session";
 
 export const metadata = {
@@ -15,39 +13,6 @@ export const metadata = {
 export default async function AddListingPage() {
   const userId = await getCurrentUserId();
   if (!userId) return null;
-
-  const user = await userDAL.getUserById(userId);
-
-  const connectOk = Boolean(
-    user.stripeConnectedAccountId &&
-    user.connectChargesEnabled &&
-    user.connectPayoutsEnabled,
-  );
-
-  if (!connectOk) {
-    return (
-      <div className="max-w-2xl">
-        <BackButton />
-        <div className="mt-4 space-y-2">
-          <h1 className="text-2xl font-bold sm:text-3xl">
-            Stripe Connect required
-          </h1>
-          <p className="text-muted-foreground text-sm sm:text-base">
-            Complete payouts onboarding before listing your tools.
-          </p>
-        </div>
-        <p className="text-muted-foreground mt-4 text-sm">
-          We use Stripe Connect to pay you safely when your tools are rented.
-          Finish onboarding, then return here to create your listing.
-        </p>
-        <Button asChild className="mt-4">
-          <Link href="/dashboard/payments/earnings-and-payouts">
-            Set up payouts
-          </Link>
-        </Button>
-      </div>
-    );
-  }
 
   const [categories, documentVersions] = await Promise.all([
     listingDAL.getListingCategories(),

--- a/src/app/dashboard/listings/rentals/page.tsx
+++ b/src/app/dashboard/listings/rentals/page.tsx
@@ -1,8 +1,6 @@
 import { Suspense } from "react";
 import { getCurrentUser } from "@/features/auth/utils/session";
 import { GarageClient } from "@/features/listings/components/garage-page/garage-client";
-import { InitiateStripeOnboarding } from "@/features/payments/components/initiate-stripe-onboarding";
-import { PageHeader } from "@/components/page-header";
 import { listingDAL } from "@/dal";
 import { db } from "@/db/db";
 import { listings } from "@/db/schemas/listings.schema";
@@ -19,27 +17,6 @@ export default async function ListingsRentalsPage() {
   const user = await getCurrentUser();
   if (!user) {
     return <div>Loading...</div>;
-  }
-
-  const isOnboarded =
-    user.connectChargesEnabled &&
-    user.connectPayoutsEnabled &&
-    user.connectOnboardingComplete;
-
-  if (!isOnboarded) {
-    return (
-      <div className="container pb-6">
-        <>
-          <div className="container pb-6">
-            <PageHeader
-              title="Your rental listings"
-              description="Manage your rental listings in one place"
-            />
-            <InitiateStripeOnboarding />{" "}
-          </div>{" "}
-        </>
-      </div>
-    );
   }
 
   const qc = getServerQueryClient();

--- a/src/app/dashboard/listings/services/page.tsx
+++ b/src/app/dashboard/listings/services/page.tsx
@@ -1,8 +1,6 @@
 import { Suspense } from "react";
-import { userDAL, serviceListingDAL } from "@/dal";
+import { serviceListingDAL } from "@/dal";
 import { getCurrentUser } from "@/features/auth/utils/session";
-import { InitiateStripeOnboarding } from "@/features/payments/components/initiate-stripe-onboarding";
-import { PageHeader } from "@/components/page-header";
 import { MyServiceListingsClient } from "@/features/services/components/my-listings-page/my-service-listings-client";
 import { getServerQueryClient, HydrateClient } from "@/lib/react-query/server";
 import { myServiceListingsKeys } from "@/features/services/hooks/use-service-listings";
@@ -16,20 +14,6 @@ export default async function ListingsServicesPage() {
   const user = await getCurrentUser();
   if (!user) {
     return <div>Loading...</div>;
-  }
-
-  const isOnboarded = await userDAL.isConnectOnboardingComplete(user.id);
-
-  if (!isOnboarded) {
-    return (
-      <div className="container pb-6">
-        <PageHeader
-          title="Your service listings"
-          description="Manage your services and availability"
-        />
-        <InitiateStripeOnboarding />
-      </div>
-    );
   }
 
   const qc = getServerQueryClient();

--- a/src/app/dashboard/payments/earnings-and-payouts/page.tsx
+++ b/src/app/dashboard/payments/earnings-and-payouts/page.tsx
@@ -1,21 +1,36 @@
 export const dynamic = "force-dynamic";
+import { redirect } from "next/navigation";
 import { PAYMENTS_PAGE_HEADERS } from "@/constants/payments";
 import { PageHeader } from "@/components/page-header";
 import { getCurrentUser } from "@/features/auth/utils/session";
 import { userDAL } from "@/dal";
 import { PaymentsTabs } from "@/features/payments/components";
 import { EarningsAndPayoutsPageClient } from "@/features/payments/components";
+import { getPayoutReadiness } from "@/features/payments/lib/payout-readiness";
+import { validateReturnTo } from "@/features/payments/lib/return-to";
+import { logGatingEvent } from "@/features/payments/lib/log-events";
 
 export const metadata = {
   title: "Earnings & payouts",
   description: "Manage your earnings, payouts, and Stripe Connect account",
 };
 
+interface PageProps {
+  searchParams: Promise<{ returnTo?: string }>;
+}
+
 /**
  * Earnings & Payouts page server component
- * Fetches user data and onboarding status server-side
+ * Fetches user data and onboarding status server-side.
+ *
+ * When called with a valid `?returnTo=<dashboard-path>` query param, the page
+ * enters JIT mode: chrome (tabs, earnings sections) is hidden and only the
+ * Stripe Connect onboarding form is rendered, with context copy and a redirect
+ * back to `returnTo` on completion. Used by the accept-booking 403 flow.
  */
-export default async function EarningsAndPayoutsPage() {
+export default async function EarningsAndPayoutsPage({
+  searchParams,
+}: PageProps) {
   const user = await getCurrentUser();
 
   if (!user) {
@@ -38,8 +53,42 @@ export default async function EarningsAndPayoutsPage() {
     );
   }
 
-  // Fetch onboarding status
-  const isOnboarded = await userDAL.isConnectOnboardingComplete(user.id);
+  const { returnTo: rawReturnTo } = await searchParams;
+  const returnTo = validateReturnTo(rawReturnTo);
+
+  const userRecord = await userDAL.getUserById(user.id);
+  const readiness = getPayoutReadiness({
+    stripeConnectedAccountId: userRecord.stripeConnectedAccountId ?? null,
+    connectChargesEnabled: userRecord.connectChargesEnabled,
+    connectPayoutsEnabled: userRecord.connectPayoutsEnabled,
+    connectOnboardingComplete: userRecord.connectOnboardingComplete,
+  });
+
+  // JIT mode: send the verified user straight back to the originating booking.
+  if (returnTo && readiness.onboardingStatus === "verified") {
+    redirect(returnTo);
+  }
+
+  // JIT mode: render only the onboarding form with context copy and skip the
+  // normal page chrome (tabs, earnings dashboard, explainer).
+  if (returnTo) {
+    logGatingEvent("connect_onboarding_started_from_accept", {
+      userId: user.id,
+      onboardingStatus: readiness.onboardingStatus,
+    });
+
+    return (
+      <div className="container pb-6">
+        <EarningsAndPayoutsPageClient
+          isOnboarded={false}
+          returnTo={returnTo}
+          onboardingStatus={readiness.onboardingStatus}
+        />
+      </div>
+    );
+  }
+
+  const isOnboarded = readiness.onboardingStatus === "verified";
 
   return (
     <div className="container pb-6">

--- a/src/app/dashboard/services/bookings/[id]/page.tsx
+++ b/src/app/dashboard/services/bookings/[id]/page.tsx
@@ -10,6 +10,7 @@ import {
   legalDocumentDAL,
   serviceAgreementDocumentDAL,
   serviceBookingDAL,
+  userDAL,
 } from "@/dal";
 import type { ServiceBookingWithDetails } from "@/dal/service-booking.dal";
 import {
@@ -18,6 +19,10 @@ import {
 } from "@/features/services/components/service-booking-detail-client";
 import { getCurrentUserId } from "@/features/auth/utils/session";
 import { BlindReviewService } from "@/features/reviews/services/blind-review-service";
+import {
+  getPayoutReadiness,
+  type OnboardingStatus,
+} from "@/features/payments/lib/payout-readiness";
 
 export const metadata = {
   title: "Booking details",
@@ -116,6 +121,25 @@ export default async function ServiceBookingDetailPage({ params }: PageProps) {
       : Promise.resolve(null),
     serviceAgreementDocumentDAL.getByServiceBookingId(id),
   ]);
+
+  // When the current user is the provider on a pending booking, fetch their
+  // payout readiness so the Accept button can pre-empt the accept dialog with
+  // a JIT onboarding prompt when Stripe Connect isn't verified.
+  const isProvider = booking.providerId === userId;
+  let providerOnboardingStatus: OnboardingStatus | undefined;
+  if (
+    isProvider &&
+    (booking.status === "pending" || booking.status === "payment_failed")
+  ) {
+    try {
+      const providerUser = await userDAL.getUserById(userId);
+      providerOnboardingStatus =
+        getPayoutReadiness(providerUser).onboardingStatus;
+    } catch {
+      // Non-critical — fall back to the existing 403 redirect path.
+    }
+  }
+
   const title = booking.listing.title;
 
   return (
@@ -132,6 +156,7 @@ export default async function ServiceBookingDetailPage({ params }: PageProps) {
           serviceAgreementUrl={serviceAgreementDoc?.pdfUrl}
           hasActiveDispute={Boolean(activeDispute)}
           canReview={reviewStatus?.canReview ?? false}
+          providerOnboardingStatus={providerOnboardingStatus}
         />
       </Suspense>
     </div>

--- a/src/app/dashboard/services/listings/create/page.tsx
+++ b/src/app/dashboard/services/listings/create/page.tsx
@@ -1,9 +1,7 @@
 export const dynamic = "force-dynamic";
 
-import Link from "next/link";
 import { PageHeader } from "@/components/page-header";
-import { Button } from "@/components/ui/button";
-import { communityDAL, serviceListingDAL, userDAL } from "@/dal";
+import { communityDAL, serviceListingDAL } from "@/dal";
 import { ServiceListingForm } from "@/features/services/components/service-listing-form";
 import { getCurrentUserId } from "@/features/auth/utils/session";
 
@@ -27,36 +25,7 @@ export default async function CreateServiceListingPage() {
     );
   }
 
-  const [user, categories] = await Promise.all([
-    userDAL.getUserById(userId),
-    serviceListingDAL.listCategories(),
-  ]);
-
-  const connectOk = Boolean(
-    user.stripeConnectedAccountId &&
-    user.connectChargesEnabled &&
-    user.connectPayoutsEnabled,
-  );
-
-  if (!connectOk) {
-    return (
-      <div className="container max-w-2xl pb-10">
-        <PageHeader
-          title="Stripe Connect required"
-          description="Complete payouts onboarding before offering services."
-        />
-        <p className="text-muted-foreground mb-4 text-sm">
-          We use Stripe Connect to pay providers safely. Finish onboarding, then
-          return here to create your listing.
-        </p>
-        <Button asChild>
-          <Link href="/dashboard/payments/earnings-and-payouts">
-            Set up payouts
-          </Link>
-        </Button>
-      </div>
-    );
-  }
+  const categories = await serviceListingDAL.listCategories();
 
   return (
     <div className="container max-w-2xl pb-10">

--- a/src/constants/payments.ts
+++ b/src/constants/payments.ts
@@ -4,6 +4,13 @@
 export const PLATFORM_FEE_PERCENTAGE = 0.2;
 
 /**
+ * How long a pending rental request or service booking remains active before
+ * the expiry cron auto-cancels it. Used by both insert sites to compute
+ * `expires_at` and by the cron to identify rows past their deadline.
+ */
+export const PENDING_BOOKING_EXPIRY_WINDOW_HOURS = 72;
+
+/**
  * Stripe's processing rate (2.9% + $0.30). Used for both the renter-facing service fee
  * and for platform net revenue calculation.
  */

--- a/src/dal/__tests__/service-booking.dal.test.ts
+++ b/src/dal/__tests__/service-booking.dal.test.ts
@@ -73,6 +73,7 @@ describe("ServiceBookingDAL", () => {
         cancelledBy: null,
         cancellationReason: null,
         completedAt: null,
+        expiresAt: new Date(Date.now() + 72 * 60 * 60 * 1000),
       });
 
       expect(result).toEqual(bookingRow);
@@ -107,6 +108,7 @@ describe("ServiceBookingDAL", () => {
           cancelledBy: null,
           cancellationReason: null,
           completedAt: null,
+          expiresAt: new Date(Date.now() + 72 * 60 * 60 * 1000),
         }),
       ).rejects.toThrow(NotFoundError);
     });

--- a/src/dal/listing.dal.ts
+++ b/src/dal/listing.dal.ts
@@ -1106,6 +1106,30 @@ export class ListingDAL extends BaseDAL {
   }
 
   /**
+   * Whether the user owns at least one published (approved, active, available-or-rented) listing.
+   * Uses LIMIT 1 — cheaper than a full count when the caller only needs a boolean.
+   */
+  async hasPublishedListings(userId: string): Promise<boolean> {
+    try {
+      const result = await this.db
+        .select({ id: listings.id })
+        .from(listings)
+        .where(
+          and(
+            eq(listings.ownerId, userId),
+            eq(listings.isActive, true),
+            eq(listings.approvalStatus, "approved"),
+            or(eq(listings.status, "available"), eq(listings.status, "rented")),
+          ),
+        )
+        .limit(1);
+      return result.length > 0;
+    } catch (error) {
+      this.handleError(error, "hasPublishedListings");
+    }
+  }
+
+  /**
    * Get platform-wide count of active listings (approved, available or rented).
    */
   async getActiveListingsCount(): Promise<number> {

--- a/src/dal/rentals.dal.ts
+++ b/src/dal/rentals.dal.ts
@@ -17,6 +17,7 @@ import { BaseDAL } from "./base";
 import { ConflictError, NotFoundError } from "./errors";
 import type { CancellationReason } from "./types";
 import { alias } from "drizzle-orm/pg-core";
+import { PENDING_BOOKING_EXPIRY_WINDOW_HOURS } from "@/constants/payments";
 
 const serviceBookingRequesterForAlerts = alias(user, "sb_req_alerts");
 const serviceBookingProviderForAlerts = alias(user, "sb_prov_alerts");
@@ -501,6 +502,9 @@ export class RentalDAL extends BaseDAL {
     payload: InsertRentalRequestPayload,
   ): Promise<{ id: string }> {
     try {
+      const expiresAt = new Date(
+        Date.now() + PENDING_BOOKING_EXPIRY_WINDOW_HOURS * 60 * 60 * 1000,
+      );
       const [rentalRequest] = await this.db
         .insert(rentalRequests)
         .values({
@@ -527,6 +531,7 @@ export class RentalDAL extends BaseDAL {
           paymentIntentId: payload.paymentIntentId,
           paymentMethodId: payload.paymentMethodId,
           status: payload.status,
+          expiresAt,
         })
         .returning();
 
@@ -1615,6 +1620,75 @@ export class RentalDAL extends BaseDAL {
       }));
     } catch (error) {
       this.handleError(error, "getLendingRentalsByStatus");
+    }
+  }
+
+  /**
+   * Returns pending rental requests whose expiresAt has passed.
+   * Drives the /api/cron/expire-pending-bookings job; uses the partial
+   * index `rental_requests_pending_expires_at_idx`.
+   */
+  async findPendingExpiredRequests(now: Date): Promise<
+    Array<{
+      id: string;
+      renterId: string;
+      ownerId: string;
+      listingId: string;
+      listingName: string;
+      securityDepositAuthId: string | null;
+    }>
+  > {
+    try {
+      const rows = await this.db
+        .select({
+          id: rentalRequests.id,
+          renterId: rentalRequests.renterId,
+          ownerId: rentalRequests.ownerId,
+          listingId: rentalRequests.listingId,
+          listingName: listings.name,
+          securityDepositAuthId: rentalRequests.securityDepositAuthId,
+        })
+        .from(rentalRequests)
+        .innerJoin(listings, eq(rentalRequests.listingId, listings.id))
+        .where(
+          and(
+            eq(rentalRequests.status, "pending"),
+            lt(rentalRequests.expiresAt, now),
+          ),
+        );
+      return rows;
+    } catch (error) {
+      this.handleError(error, "findPendingExpiredRequests");
+    }
+  }
+
+  /**
+   * Atomically transitions a rental request to `cancelled` with
+   * cancellationReason='expired_no_acceptance'. The WHERE clause guards
+   * against double-expiry under concurrent cron ticks.
+   *
+   * @returns `true` if a row was updated, `false` if the row was no longer pending.
+   */
+  async markRequestExpired(requestId: string): Promise<boolean> {
+    try {
+      const updated = await this.db
+        .update(rentalRequests)
+        .set({
+          status: "cancelled",
+          cancelledAt: new Date(),
+          cancellationReason: "expired_no_acceptance",
+          updatedAt: new Date(),
+        })
+        .where(
+          and(
+            eq(rentalRequests.id, requestId),
+            eq(rentalRequests.status, "pending"),
+          ),
+        )
+        .returning({ id: rentalRequests.id });
+      return updated.length > 0;
+    } catch (error) {
+      this.handleError(error, "markRequestExpired");
     }
   }
 

--- a/src/dal/service-booking.dal.ts
+++ b/src/dal/service-booking.dal.ts
@@ -1,4 +1,4 @@
-import { and, count, desc, eq, sql } from "drizzle-orm";
+import { and, count, desc, eq, lt, sql } from "drizzle-orm";
 import { alias } from "drizzle-orm/pg-core";
 
 import {
@@ -105,6 +105,76 @@ export class ServiceBookingDAL extends BaseDAL {
       return row;
     } catch (error) {
       this.handleError(error, "ServiceBookingDAL.update");
+    }
+  }
+
+  /**
+   * Returns pending service bookings whose expiresAt has passed.
+   * Drives the /api/cron/expire-pending-bookings job; uses the partial
+   * index `sb_pending_expires_at_idx`.
+   */
+  async findPendingExpired(now: Date): Promise<
+    Array<{
+      id: string;
+      requesterId: string;
+      providerId: string;
+      listingId: string;
+      listingTitle: string;
+    }>
+  > {
+    try {
+      const rows = await this.db
+        .select({
+          id: serviceBookings.id,
+          requesterId: serviceBookings.requesterId,
+          providerId: serviceBookings.providerId,
+          listingId: serviceBookings.listingId,
+          listingTitle: serviceListings.title,
+        })
+        .from(serviceBookings)
+        .innerJoin(
+          serviceListings,
+          eq(serviceBookings.listingId, serviceListings.id),
+        )
+        .where(
+          and(
+            eq(serviceBookings.status, "pending"),
+            lt(serviceBookings.expiresAt, now),
+          ),
+        );
+      return rows;
+    } catch (error) {
+      this.handleError(error, "ServiceBookingDAL.findPendingExpired");
+    }
+  }
+
+  /**
+   * Atomically transitions a service booking to `cancelled` with
+   * cancellationReason='expired_no_acceptance'. The WHERE clause guards
+   * against double-expiry under concurrent cron ticks.
+   *
+   * @returns `true` if a row was updated, `false` if the row was no longer pending.
+   */
+  async markExpired(bookingId: string): Promise<boolean> {
+    try {
+      const updated = await this.db
+        .update(serviceBookings)
+        .set({
+          status: "cancelled",
+          cancelledAt: new Date(),
+          cancellationReason: "expired_no_acceptance",
+          updatedAt: new Date(),
+        })
+        .where(
+          and(
+            eq(serviceBookings.id, bookingId),
+            eq(serviceBookings.status, "pending"),
+          ),
+        )
+        .returning({ id: serviceBookings.id });
+      return updated.length > 0;
+    } catch (error) {
+      this.handleError(error, "ServiceBookingDAL.markExpired");
     }
   }
 

--- a/src/dal/service-listing.dal.ts
+++ b/src/dal/service-listing.dal.ts
@@ -820,6 +820,28 @@ export class ServiceListingDAL extends BaseDAL {
   }
 
   /**
+   * Whether the provider owns at least one published (status='active') service listing.
+   * Uses LIMIT 1 — cheaper than a full count when the caller only needs a boolean.
+   */
+  async hasPublishedListings(providerId: string): Promise<boolean> {
+    try {
+      const result = await this.db
+        .select({ id: serviceListings.id })
+        .from(serviceListings)
+        .where(
+          and(
+            eq(serviceListings.providerId, providerId),
+            eq(serviceListings.status, "active"),
+          ),
+        )
+        .limit(1);
+      return result.length > 0;
+    } catch (error) {
+      this.handleError(error, "ServiceListingDAL.hasPublishedListings");
+    }
+  }
+
+  /**
    * All listings owned by a provider (any status).
    */
   async findByProvider(providerId: string): Promise<ServiceListing[]> {

--- a/src/db/migrations/0062_strong_screwball.sql
+++ b/src/db/migrations/0062_strong_screwball.sql
@@ -1,0 +1,18 @@
+-- Add `expires_at` to rental_requests and service_bookings, with a partial index
+-- on pending rows so the expiry cron's lookup stays cheap. Existing rows are
+-- backfilled from created_at + 72h so the NOT NULL constraint is safe on a
+-- non-empty table. Also extends cancellation_reason enum with the
+-- 'expired_no_acceptance' value used by the cron when it auto-cancels.
+
+ALTER TYPE "public"."cancellation_reason" ADD VALUE 'expired_no_acceptance';--> statement-breakpoint
+
+ALTER TABLE "rental_requests" ADD COLUMN "expires_at" timestamp;--> statement-breakpoint
+UPDATE "rental_requests" SET "expires_at" = "created_at" + interval '72 hours' WHERE "expires_at" IS NULL;--> statement-breakpoint
+ALTER TABLE "rental_requests" ALTER COLUMN "expires_at" SET NOT NULL;--> statement-breakpoint
+
+ALTER TABLE "service_bookings" ADD COLUMN "expires_at" timestamp;--> statement-breakpoint
+UPDATE "service_bookings" SET "expires_at" = "created_at" + interval '72 hours' WHERE "expires_at" IS NULL;--> statement-breakpoint
+ALTER TABLE "service_bookings" ALTER COLUMN "expires_at" SET NOT NULL;--> statement-breakpoint
+
+CREATE INDEX "rental_requests_pending_expires_at_idx" ON "rental_requests" USING btree ("expires_at") WHERE status = 'pending';--> statement-breakpoint
+CREATE INDEX "sb_pending_expires_at_idx" ON "service_bookings" USING btree ("expires_at") WHERE status = 'pending';

--- a/src/db/migrations/meta/0062_snapshot.json
+++ b/src/db/migrations/meta/0062_snapshot.json
@@ -1,0 +1,7727 @@
+{
+  "id": "1c882cb1-fe16-492c-8932-a271f81e75ef",
+  "prevId": "d210e0f9-63cd-455f-9cd0-36d178e9a813",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_logs": {
+      "name": "audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_logs_entity_type_entity_id_idx": {
+          "name": "audit_logs_entity_type_entity_id_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_logs_user_id_created_at_idx": {
+          "name": "audit_logs_user_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_logs_action_created_at_idx": {
+          "name": "audit_logs_action_created_at_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_logs_created_at_idx": {
+          "name": "audit_logs_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_logs_user_id_user_id_fk": {
+          "name": "audit_logs_user_id_user_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blind_reviews": {
+      "name": "blind_reviews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "rental_id": {
+          "name": "rental_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "service_booking_id": {
+          "name": "service_booking_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewer_id": {
+          "name": "reviewer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reviewee_id": {
+          "name": "reviewee_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "released_at": {
+          "name": "released_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_window_end_at": {
+          "name": "review_window_end_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "blind_reviews_reviewer_rental_idx": {
+          "name": "blind_reviews_reviewer_rental_idx",
+          "columns": [
+            {
+              "expression": "reviewer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rental_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"blind_reviews\".\"rental_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "blind_reviews_reviewer_service_booking_idx": {
+          "name": "blind_reviews_reviewer_service_booking_idx",
+          "columns": [
+            {
+              "expression": "reviewer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "service_booking_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"blind_reviews\".\"service_booking_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "blind_reviews_rental_id_idx": {
+          "name": "blind_reviews_rental_id_idx",
+          "columns": [
+            {
+              "expression": "rental_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "blind_reviews_service_booking_id_idx": {
+          "name": "blind_reviews_service_booking_id_idx",
+          "columns": [
+            {
+              "expression": "service_booking_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "blind_reviews_reviewee_id_idx": {
+          "name": "blind_reviews_reviewee_id_idx",
+          "columns": [
+            {
+              "expression": "reviewee_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "blind_reviews_released_at_idx": {
+          "name": "blind_reviews_released_at_idx",
+          "columns": [
+            {
+              "expression": "released_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "blind_reviews_pending_release_idx": {
+          "name": "blind_reviews_pending_release_idx",
+          "columns": [
+            {
+              "expression": "review_window_end_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"blind_reviews\".\"released_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "blind_reviews_rental_id_rentals_id_fk": {
+          "name": "blind_reviews_rental_id_rentals_id_fk",
+          "tableFrom": "blind_reviews",
+          "tableTo": "rentals",
+          "columnsFrom": ["rental_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "blind_reviews_service_booking_id_service_bookings_id_fk": {
+          "name": "blind_reviews_service_booking_id_service_bookings_id_fk",
+          "tableFrom": "blind_reviews",
+          "tableTo": "service_bookings",
+          "columnsFrom": ["service_booking_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "blind_reviews_reviewer_id_user_id_fk": {
+          "name": "blind_reviews_reviewer_id_user_id_fk",
+          "tableFrom": "blind_reviews",
+          "tableTo": "user",
+          "columnsFrom": ["reviewer_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "blind_reviews_reviewee_id_user_id_fk": {
+          "name": "blind_reviews_reviewee_id_user_id_fk",
+          "tableFrom": "blind_reviews",
+          "tableTo": "user",
+          "columnsFrom": ["reviewee_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "booking_ref_check": {
+          "name": "booking_ref_check",
+          "value": "num_nonnulls(\"blind_reviews\".\"rental_id\", \"blind_reviews\".\"service_booking_id\") = 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.collection_items": {
+      "name": "collection_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "collection_id": {
+          "name": "collection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "listing_id": {
+          "name": "listing_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "collection_items_collection_listing_idx": {
+          "name": "collection_items_collection_listing_idx",
+          "columns": [
+            {
+              "expression": "collection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "listing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "collection_items_collection_id_idx": {
+          "name": "collection_items_collection_id_idx",
+          "columns": [
+            {
+              "expression": "collection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "collection_items_listing_id_idx": {
+          "name": "collection_items_listing_id_idx",
+          "columns": [
+            {
+              "expression": "listing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "collection_items_collection_id_user_collections_id_fk": {
+          "name": "collection_items_collection_id_user_collections_id_fk",
+          "tableFrom": "collection_items",
+          "tableTo": "user_collections",
+          "columnsFrom": ["collection_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "collection_items_listing_id_listings_id_fk": {
+          "name": "collection_items_listing_id_listings_id_fk",
+          "tableFrom": "collection_items",
+          "tableTo": "listings",
+          "columnsFrom": ["listing_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_collections": {
+      "name": "user_collections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_collections_user_id_idx": {
+          "name": "user_collections_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_collections_user_id_user_id_fk": {
+          "name": "user_collections_user_id_user_id_fk",
+          "tableFrom": "user_collections",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_favorites": {
+      "name": "user_favorites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "listing_id": {
+          "name": "listing_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_favorites_user_listing_idx": {
+          "name": "user_favorites_user_listing_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "listing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_favorites_user_id_idx": {
+          "name": "user_favorites_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_favorites_listing_id_idx": {
+          "name": "user_favorites_listing_id_idx",
+          "columns": [
+            {
+              "expression": "listing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_favorites_user_id_user_id_fk": {
+          "name": "user_favorites_user_id_user_id_fk",
+          "tableFrom": "user_favorites",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_favorites_listing_id_listings_id_fk": {
+          "name": "user_favorites_listing_id_listings_id_fk",
+          "tableFrom": "user_favorites",
+          "tableTo": "listings",
+          "columnsFrom": ["listing_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.communities": {
+      "name": "communities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "join_code": {
+          "name": "join_code",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "zip": {
+          "name": "zip",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "network_id": {
+          "name": "network_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "numeric(10, 8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "numeric(11, 8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "communities_join_code_idx": {
+          "name": "communities_join_code_idx",
+          "columns": [
+            {
+              "expression": "join_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communities_name_idx": {
+          "name": "communities_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communities_city_state_idx": {
+          "name": "communities_city_state_idx",
+          "columns": [
+            {
+              "expression": "city",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communities_network_id_idx": {
+          "name": "communities_network_id_idx",
+          "columns": [
+            {
+              "expression": "network_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "communities_network_id_community_networks_id_fk": {
+          "name": "communities_network_id_community_networks_id_fk",
+          "tableFrom": "communities",
+          "tableTo": "community_networks",
+          "columnsFrom": ["network_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "communities_join_code_unique": {
+          "name": "communities_join_code_unique",
+          "nullsNotDistinct": false,
+          "columns": ["join_code"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_memberships": {
+      "name": "community_memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "community_id": {
+          "name": "community_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "community_membership_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "verification_status": {
+          "name": "verification_status",
+          "type": "verification_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_by": {
+          "name": "verified_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "admin_notes": {
+          "name": "admin_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "community_memberships_user_id_idx": {
+          "name": "community_memberships_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "community_memberships_community_id_idx": {
+          "name": "community_memberships_community_id_idx",
+          "columns": [
+            {
+              "expression": "community_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "community_memberships_user_community_idx": {
+          "name": "community_memberships_user_community_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "community_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "community_memberships_user_primary_idx": {
+          "name": "community_memberships_user_primary_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"community_memberships\".\"is_primary\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "community_memberships_verification_status_idx": {
+          "name": "community_memberships_verification_status_idx",
+          "columns": [
+            {
+              "expression": "verification_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_memberships_user_id_user_id_fk": {
+          "name": "community_memberships_user_id_user_id_fk",
+          "tableFrom": "community_memberships",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_memberships_community_id_communities_id_fk": {
+          "name": "community_memberships_community_id_communities_id_fk",
+          "tableFrom": "community_memberships",
+          "tableTo": "communities",
+          "columnsFrom": ["community_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_memberships_verified_by_user_id_fk": {
+          "name": "community_memberships_verified_by_user_id_fk",
+          "tableFrom": "community_memberships",
+          "tableTo": "user",
+          "columnsFrom": ["verified_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_networks": {
+      "name": "community_networks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "community_networks_name_idx": {
+          "name": "community_networks_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "community_networks_slug_idx": {
+          "name": "community_networks_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_visibility": {
+      "name": "community_visibility",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "community_id": {
+          "name": "community_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_visible": {
+          "name": "is_visible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "community_visibility_user_community_idx": {
+          "name": "community_visibility_user_community_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "community_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "community_visibility_user_visible_idx": {
+          "name": "community_visibility_user_visible_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"community_visibility\".\"is_visible\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "community_visibility_community_visible_idx": {
+          "name": "community_visibility_community_visible_idx",
+          "columns": [
+            {
+              "expression": "community_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"community_visibility\".\"is_visible\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "community_visibility_user_id_user_id_fk": {
+          "name": "community_visibility_user_id_user_id_fk",
+          "tableFrom": "community_visibility",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_visibility_community_id_communities_id_fk": {
+          "name": "community_visibility_community_id_communities_id_fk",
+          "tableFrom": "community_visibility",
+          "tableTo": "communities",
+          "columnsFrom": ["community_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cron_run_history": {
+      "name": "cron_run_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "job_name": {
+          "name": "job_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "records_eligible": {
+          "name": "records_eligible",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "records_succeeded": {
+          "name": "records_succeeded",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "records_failed": {
+          "name": "records_failed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "crh_job_name_idx": {
+          "name": "crh_job_name_idx",
+          "columns": [
+            {
+              "expression": "job_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "crh_started_at_idx": {
+          "name": "crh_started_at_idx",
+          "columns": [
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dispute_audit_logs": {
+      "name": "dispute_audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "dispute_id": {
+          "name": "dispute_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "audit_action_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_state": {
+          "name": "previous_state",
+          "type": "dispute_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_state": {
+          "name": "new_state",
+          "type": "dispute_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "dispute_audit_logs_dispute_id_idx": {
+          "name": "dispute_audit_logs_dispute_id_idx",
+          "columns": [
+            {
+              "expression": "dispute_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dispute_audit_logs_user_id_idx": {
+          "name": "dispute_audit_logs_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dispute_audit_logs_action_type_idx": {
+          "name": "dispute_audit_logs_action_type_idx",
+          "columns": [
+            {
+              "expression": "action_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dispute_audit_logs_created_at_idx": {
+          "name": "dispute_audit_logs_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dispute_audit_logs_dispute_id_disputes_id_fk": {
+          "name": "dispute_audit_logs_dispute_id_disputes_id_fk",
+          "tableFrom": "dispute_audit_logs",
+          "tableTo": "disputes",
+          "columnsFrom": ["dispute_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "dispute_audit_logs_user_id_user_id_fk": {
+          "name": "dispute_audit_logs_user_id_user_id_fk",
+          "tableFrom": "dispute_audit_logs",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dispute_evidence": {
+      "name": "dispute_evidence",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "dispute_id": {
+          "name": "dispute_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_by_role": {
+          "name": "uploaded_by_role",
+          "type": "dispute_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence_type": {
+          "name": "evidence_type",
+          "type": "evidence_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_at": {
+          "name": "uploaded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "dispute_evidence_dispute_id_idx": {
+          "name": "dispute_evidence_dispute_id_idx",
+          "columns": [
+            {
+              "expression": "dispute_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dispute_evidence_uploaded_by_idx": {
+          "name": "dispute_evidence_uploaded_by_idx",
+          "columns": [
+            {
+              "expression": "uploaded_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dispute_evidence_uploaded_at_idx": {
+          "name": "dispute_evidence_uploaded_at_idx",
+          "columns": [
+            {
+              "expression": "uploaded_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dispute_evidence_dispute_id_disputes_id_fk": {
+          "name": "dispute_evidence_dispute_id_disputes_id_fk",
+          "tableFrom": "dispute_evidence",
+          "tableTo": "disputes",
+          "columnsFrom": ["dispute_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "dispute_evidence_uploaded_by_user_id_fk": {
+          "name": "dispute_evidence_uploaded_by_user_id_fk",
+          "tableFrom": "dispute_evidence",
+          "tableTo": "user",
+          "columnsFrom": ["uploaded_by"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dispute_financial_operations": {
+      "name": "dispute_financial_operations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "dispute_id": {
+          "name": "dispute_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_type": {
+          "name": "operation_type",
+          "type": "financial_operation_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_operation_id": {
+          "name": "stripe_operation_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_payment_intent_id": {
+          "name": "stripe_payment_intent_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_transfer_id": {
+          "name": "stripe_transfer_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "financial_operation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "performed_by": {
+          "name": "performed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "performed_at": {
+          "name": "performed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "dispute_financial_operations_dispute_id_idx": {
+          "name": "dispute_financial_operations_dispute_id_idx",
+          "columns": [
+            {
+              "expression": "dispute_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dispute_financial_operations_stripe_operation_id_idx": {
+          "name": "dispute_financial_operations_stripe_operation_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dispute_financial_operations_status_idx": {
+          "name": "dispute_financial_operations_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dispute_financial_operations_dispute_id_disputes_id_fk": {
+          "name": "dispute_financial_operations_dispute_id_disputes_id_fk",
+          "tableFrom": "dispute_financial_operations",
+          "tableTo": "disputes",
+          "columnsFrom": ["dispute_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "dispute_financial_operations_performed_by_user_id_fk": {
+          "name": "dispute_financial_operations_performed_by_user_id_fk",
+          "tableFrom": "dispute_financial_operations",
+          "tableTo": "user",
+          "columnsFrom": ["performed_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dispute_internal_notes": {
+      "name": "dispute_internal_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "dispute_id": {
+          "name": "dispute_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "admin_id": {
+          "name": "admin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "dispute_internal_notes_dispute_id_idx": {
+          "name": "dispute_internal_notes_dispute_id_idx",
+          "columns": [
+            {
+              "expression": "dispute_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dispute_internal_notes_admin_id_idx": {
+          "name": "dispute_internal_notes_admin_id_idx",
+          "columns": [
+            {
+              "expression": "admin_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dispute_internal_notes_created_at_idx": {
+          "name": "dispute_internal_notes_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dispute_internal_notes_dispute_id_disputes_id_fk": {
+          "name": "dispute_internal_notes_dispute_id_disputes_id_fk",
+          "tableFrom": "dispute_internal_notes",
+          "tableTo": "disputes",
+          "columnsFrom": ["dispute_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "dispute_internal_notes_admin_id_user_id_fk": {
+          "name": "dispute_internal_notes_admin_id_user_id_fk",
+          "tableFrom": "dispute_internal_notes",
+          "tableTo": "user",
+          "columnsFrom": ["admin_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.disputes": {
+      "name": "disputes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "reference_number": {
+          "name": "reference_number",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rental_id": {
+          "name": "rental_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "service_booking_id": {
+          "name": "service_booking_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_role": {
+          "name": "created_by_role",
+          "type": "dispute_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason_code": {
+          "name": "reason_code",
+          "type": "dispute_reason_code",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "dispute_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "policy_version": {
+          "name": "policy_version",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence_deadline": {
+          "name": "evidence_deadline",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "additional_evidence_deadline": {
+          "name": "additional_evidence_deadline",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution_outcome": {
+          "name": "resolution_outcome",
+          "type": "dispute_resolution_outcome",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution_reason": {
+          "name": "resolution_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_chargeback_id": {
+          "name": "stripe_chargeback_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "disputes_reference_number_idx": {
+          "name": "disputes_reference_number_idx",
+          "columns": [
+            {
+              "expression": "reference_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "disputes_rental_id_unique": {
+          "name": "disputes_rental_id_unique",
+          "columns": [
+            {
+              "expression": "rental_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "disputes_service_booking_id_unique": {
+          "name": "disputes_service_booking_id_unique",
+          "columns": [
+            {
+              "expression": "service_booking_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "disputes_rental_id_idx": {
+          "name": "disputes_rental_id_idx",
+          "columns": [
+            {
+              "expression": "rental_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "disputes_service_booking_id_idx": {
+          "name": "disputes_service_booking_id_idx",
+          "columns": [
+            {
+              "expression": "service_booking_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "disputes_created_by_idx": {
+          "name": "disputes_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "disputes_status_idx": {
+          "name": "disputes_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "disputes_reason_code_idx": {
+          "name": "disputes_reason_code_idx",
+          "columns": [
+            {
+              "expression": "reason_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "disputes_created_at_idx": {
+          "name": "disputes_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "disputes_rental_id_status_idx": {
+          "name": "disputes_rental_id_status_idx",
+          "columns": [
+            {
+              "expression": "rental_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "disputes_service_booking_id_status_idx": {
+          "name": "disputes_service_booking_id_status_idx",
+          "columns": [
+            {
+              "expression": "service_booking_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "disputes_rental_id_rentals_id_fk": {
+          "name": "disputes_rental_id_rentals_id_fk",
+          "tableFrom": "disputes",
+          "tableTo": "rentals",
+          "columnsFrom": ["rental_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "disputes_service_booking_id_service_bookings_id_fk": {
+          "name": "disputes_service_booking_id_service_bookings_id_fk",
+          "tableFrom": "disputes",
+          "tableTo": "service_bookings",
+          "columnsFrom": ["service_booking_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "disputes_created_by_user_id_fk": {
+          "name": "disputes_created_by_user_id_fk",
+          "tableFrom": "disputes",
+          "tableTo": "user",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "disputes_resolved_by_user_id_fk": {
+          "name": "disputes_resolved_by_user_id_fk",
+          "tableFrom": "disputes",
+          "tableTo": "user",
+          "columnsFrom": ["resolved_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "disputes_rental_xor_service_booking_ck": {
+          "name": "disputes_rental_xor_service_booking_ck",
+          "value": "(\"disputes\".\"rental_id\" IS NOT NULL AND \"disputes\".\"service_booking_id\" IS NULL) OR (\"disputes\".\"rental_id\" IS NULL AND \"disputes\".\"service_booking_id\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.legal_documents": {
+      "name": "legal_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "legal_documents_id_version_pk": {
+          "name": "legal_documents_id_version_pk",
+          "columns": ["id", "version"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_legal_acceptances": {
+      "name": "user_legal_acceptances",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rental_request_id": {
+          "name": "rental_request_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "listing_id": {
+          "name": "listing_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "method": {
+          "name": "method",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_legal_acceptances_user_id_idx": {
+          "name": "user_legal_acceptances_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_legal_acceptances_document_id_idx": {
+          "name": "user_legal_acceptances_document_id_idx",
+          "columns": [
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_legal_acceptances_user_document_idx": {
+          "name": "user_legal_acceptances_user_document_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_legal_acceptances_rental_request_id_idx": {
+          "name": "user_legal_acceptances_rental_request_id_idx",
+          "columns": [
+            {
+              "expression": "rental_request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_legal_acceptances_listing_id_idx": {
+          "name": "user_legal_acceptances_listing_id_idx",
+          "columns": [
+            {
+              "expression": "listing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_legal_acceptances_user_id_user_id_fk": {
+          "name": "user_legal_acceptances_user_id_user_id_fk",
+          "tableFrom": "user_legal_acceptances",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_legal_acceptances_rental_request_id_rental_requests_id_fk": {
+          "name": "user_legal_acceptances_rental_request_id_rental_requests_id_fk",
+          "tableFrom": "user_legal_acceptances",
+          "tableTo": "rental_requests",
+          "columnsFrom": ["rental_request_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_legal_acceptances_listing_id_listings_id_fk": {
+          "name": "user_legal_acceptances_listing_id_listings_id_fk",
+          "tableFrom": "user_legal_acceptances",
+          "tableTo": "listings",
+          "columnsFrom": ["listing_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.listing_categories": {
+      "name": "listing_categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "listing_categories_name_idx": {
+          "name": "listing_categories_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "listing_categories_parent_id_idx": {
+          "name": "listing_categories_parent_id_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "listing_categories_name_unique": {
+          "name": "listing_categories_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.listing_availability": {
+      "name": "listing_availability",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "listing_id": {
+          "name": "listing_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_blocked": {
+          "name": "is_blocked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "listing_availability_listing_id_idx": {
+          "name": "listing_availability_listing_id_idx",
+          "columns": [
+            {
+              "expression": "listing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "listing_availability_date_range_idx": {
+          "name": "listing_availability_date_range_idx",
+          "columns": [
+            {
+              "expression": "start_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "end_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "listing_availability_listing_id_listings_id_fk": {
+          "name": "listing_availability_listing_id_listings_id_fk",
+          "tableFrom": "listing_availability",
+          "tableTo": "listings",
+          "columnsFrom": ["listing_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.listing_images": {
+      "name": "listing_images",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "listing_id": {
+          "name": "listing_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blob_pathname": {
+          "name": "blob_pathname",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order_index": {
+          "name": "order_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "listing_images_listing_id_idx": {
+          "name": "listing_images_listing_id_idx",
+          "columns": [
+            {
+              "expression": "listing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "listing_images_listing_id_order_idx": {
+          "name": "listing_images_listing_id_order_idx",
+          "columns": [
+            {
+              "expression": "listing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "order_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "listing_images_listing_id_listings_id_fk": {
+          "name": "listing_images_listing_id_listings_id_fk",
+          "tableFrom": "listing_images",
+          "tableTo": "listings",
+          "columnsFrom": ["listing_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.listings": {
+      "name": "listings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "community_id": {
+          "name": "community_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "brand": {
+          "name": "brand",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "condition": {
+          "name": "condition",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "daily_rate": {
+          "name": "daily_rate",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weekly_rate": {
+          "name": "weekly_rate",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "monthly_rate": {
+          "name": "monthly_rate",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "security_deposit": {
+          "name": "security_deposit",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "status": {
+          "name": "status",
+          "type": "listing_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'available'"
+        },
+        "specifications": {
+          "name": "specifications",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "safety_notes": {
+          "name": "safety_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "minimum_rental_period": {
+          "name": "minimum_rental_period",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "maximum_rental_period": {
+          "name": "maximum_rental_period",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 30
+        },
+        "delivery_mode": {
+          "name": "delivery_mode",
+          "type": "delivery_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pickup_only'"
+        },
+        "delivery_fee": {
+          "name": "delivery_fee",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "delivery_radius": {
+          "name": "delivery_radius",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "setup_fee": {
+          "name": "setup_fee",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "setup_available": {
+          "name": "setup_available",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "view_count": {
+          "name": "view_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "favorite_count": {
+          "name": "favorite_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "approval_status": {
+          "name": "approval_status",
+          "type": "approval_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending_review'"
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "listings_owner_id_idx": {
+          "name": "listings_owner_id_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "listings_community_id_idx": {
+          "name": "listings_community_id_idx",
+          "columns": [
+            {
+              "expression": "community_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "listings_category_id_idx": {
+          "name": "listings_category_id_idx",
+          "columns": [
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "listings_status_idx": {
+          "name": "listings_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "listings_daily_rate_idx": {
+          "name": "listings_daily_rate_idx",
+          "columns": [
+            {
+              "expression": "daily_rate",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "listings_name_search_idx": {
+          "name": "listings_name_search_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "listings_community_status_idx": {
+          "name": "listings_community_status_idx",
+          "columns": [
+            {
+              "expression": "community_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "listings_approval_status_idx": {
+          "name": "listings_approval_status_idx",
+          "columns": [
+            {
+              "expression": "approval_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "listings_status_approval_status_idx": {
+          "name": "listings_status_approval_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "approval_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "listings_reviewed_at_idx": {
+          "name": "listings_reviewed_at_idx",
+          "columns": [
+            {
+              "expression": "reviewed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "listings_owner_id_user_id_fk": {
+          "name": "listings_owner_id_user_id_fk",
+          "tableFrom": "listings",
+          "tableTo": "user",
+          "columnsFrom": ["owner_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "listings_community_id_communities_id_fk": {
+          "name": "listings_community_id_communities_id_fk",
+          "tableFrom": "listings",
+          "tableTo": "communities",
+          "columnsFrom": ["community_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "listings_category_id_listing_categories_id_fk": {
+          "name": "listings_category_id_listing_categories_id_fk",
+          "tableFrom": "listings",
+          "tableTo": "listing_categories",
+          "columnsFrom": ["category_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "listings_reviewed_by_user_id_fk": {
+          "name": "listings_reviewed_by_user_id_fk",
+          "tableFrom": "listings",
+          "tableTo": "user",
+          "columnsFrom": ["reviewed_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversations": {
+      "name": "conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user1_id": {
+          "name": "user1_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user2_id": {
+          "name": "user2_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user1_last_read_at": {
+          "name": "user1_last_read_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user2_last_read_at": {
+          "name": "user2_last_read_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user1_archived": {
+          "name": "user1_archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "user2_archived": {
+          "name": "user2_archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversations_user1_idx": {
+          "name": "conversations_user1_idx",
+          "columns": [
+            {
+              "expression": "user1_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_user2_idx": {
+          "name": "conversations_user2_idx",
+          "columns": [
+            {
+              "expression": "user2_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_last_message_at_idx": {
+          "name": "conversations_last_message_at_idx",
+          "columns": [
+            {
+              "expression": "last_message_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversations_user1_id_user_id_fk": {
+          "name": "conversations_user1_id_user_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "user",
+          "columnsFrom": ["user1_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "conversations_user2_id_user_id_fk": {
+          "name": "conversations_user2_id_user_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "user",
+          "columnsFrom": ["user2_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "conversations_unique_user_pair": {
+          "name": "conversations_unique_user_pair",
+          "nullsNotDistinct": false,
+          "columns": ["user1_id", "user2_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "message_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'sent'"
+        },
+        "rental_id": {
+          "name": "rental_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "listing_id": {
+          "name": "listing_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "service_listing_id": {
+          "name": "service_listing_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edited_at": {
+          "name": "edited_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "messages_conversation_id_idx": {
+          "name": "messages_conversation_id_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_sender_id_idx": {
+          "name": "messages_sender_id_idx",
+          "columns": [
+            {
+              "expression": "sender_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_rental_id_idx": {
+          "name": "messages_rental_id_idx",
+          "columns": [
+            {
+              "expression": "rental_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_listing_id_idx": {
+          "name": "messages_listing_id_idx",
+          "columns": [
+            {
+              "expression": "listing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_service_listing_id_idx": {
+          "name": "messages_service_listing_id_idx",
+          "columns": [
+            {
+              "expression": "service_listing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_created_at_idx": {
+          "name": "messages_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_last_message_at_idx": {
+          "name": "messages_last_message_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messages_conversation_id_conversations_id_fk": {
+          "name": "messages_conversation_id_conversations_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "conversations",
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_sender_id_user_id_fk": {
+          "name": "messages_sender_id_user_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "user",
+          "columnsFrom": ["sender_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_rental_id_rentals_id_fk": {
+          "name": "messages_rental_id_rentals_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "rentals",
+          "columnsFrom": ["rental_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "messages_listing_id_listings_id_fk": {
+          "name": "messages_listing_id_listings_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "listings",
+          "columnsFrom": ["listing_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "messages_service_listing_id_service_listings_id_fk": {
+          "name": "messages_service_listing_id_service_listings_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "service_listings",
+          "columnsFrom": ["service_listing_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_category_preferences": {
+      "name": "notification_category_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "notification_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "push": {
+          "name": "push",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notification_category_preferences_user_id_idx": {
+          "name": "notification_category_preferences_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notification_category_preferences_user_category_unique": {
+          "name": "notification_category_preferences_user_category_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_category_preferences_user_id_user_id_fk": {
+          "name": "notification_category_preferences_user_id_user_id_fk",
+          "tableFrom": "notification_category_preferences",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "notification_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notifications_user_id_idx": {
+          "name": "notifications_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_type_idx": {
+          "name": "notifications_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_is_read_idx": {
+          "name": "notifications_is_read_idx",
+          "columns": [
+            {
+              "expression": "is_read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_user_id_user_id_fk": {
+          "name": "notifications_user_id_user_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.push_notification_audit": {
+      "name": "push_notification_audit",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscription_id": {
+          "name": "subscription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "push_notification_audit_user_id_idx": {
+          "name": "push_notification_audit_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "push_notification_audit_sent_at_idx": {
+          "name": "push_notification_audit_sent_at_idx",
+          "columns": [
+            {
+              "expression": "sent_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "push_notification_audit_event_type_idx": {
+          "name": "push_notification_audit_event_type_idx",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "push_notification_audit_user_id_user_id_fk": {
+          "name": "push_notification_audit_user_id_user_id_fk",
+          "tableFrom": "push_notification_audit",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "push_notification_audit_subscription_id_push_subscriptions_id_fk": {
+          "name": "push_notification_audit_subscription_id_push_subscriptions_id_fk",
+          "tableFrom": "push_notification_audit",
+          "tableTo": "push_subscriptions",
+          "columnsFrom": ["subscription_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.push_subscriptions": {
+      "name": "push_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "p256dh": {
+          "name": "p256dh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth": {
+          "name": "auth",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "push_subscription_platform",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'web'"
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "push_subscriptions_user_id_idx": {
+          "name": "push_subscriptions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "push_subscriptions_endpoint_idx": {
+          "name": "push_subscriptions_endpoint_idx",
+          "columns": [
+            {
+              "expression": "endpoint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "push_subscriptions_user_id_active_idx": {
+          "name": "push_subscriptions_user_id_active_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "push_subscriptions_user_id_user_id_fk": {
+          "name": "push_subscriptions_user_id_user_id_fk",
+          "tableFrom": "push_subscriptions",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payments": {
+      "name": "payments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "rental_id": {
+          "name": "rental_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "service_booking_id": {
+          "name": "service_booking_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payer_id": {
+          "name": "payer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payee_id": {
+          "name": "payee_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform_fee": {
+          "name": "platform_fee",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "payment_method_id": {
+          "name": "payment_method_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_payment_intent_id": {
+          "name": "stripe_payment_intent_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "payment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "payment_type": {
+          "name": "payment_type",
+          "type": "payment_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'rental_charge'"
+        },
+        "paid_at": {
+          "name": "paid_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refunded_at": {
+          "name": "refunded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refund_amount": {
+          "name": "refund_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refund_reason": {
+          "name": "refund_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payments_rental_id_idx": {
+          "name": "payments_rental_id_idx",
+          "columns": [
+            {
+              "expression": "rental_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payments_service_booking_id_idx": {
+          "name": "payments_service_booking_id_idx",
+          "columns": [
+            {
+              "expression": "service_booking_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payments_payer_id_idx": {
+          "name": "payments_payer_id_idx",
+          "columns": [
+            {
+              "expression": "payer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payments_payee_id_idx": {
+          "name": "payments_payee_id_idx",
+          "columns": [
+            {
+              "expression": "payee_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payments_status_idx": {
+          "name": "payments_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payments_stripe_payment_intent_idx": {
+          "name": "payments_stripe_payment_intent_idx",
+          "columns": [
+            {
+              "expression": "stripe_payment_intent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payments_rental_id_rentals_id_fk": {
+          "name": "payments_rental_id_rentals_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "rentals",
+          "columnsFrom": ["rental_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payments_service_booking_id_service_bookings_id_fk": {
+          "name": "payments_service_booking_id_service_bookings_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "service_bookings",
+          "columnsFrom": ["service_booking_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payments_payer_id_user_id_fk": {
+          "name": "payments_payer_id_user_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "user",
+          "columnsFrom": ["payer_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payments_payee_id_user_id_fk": {
+          "name": "payments_payee_id_user_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "user",
+          "columnsFrom": ["payee_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rental_agreement_documents": {
+      "name": "rental_agreement_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "rental_request_id": {
+          "name": "rental_request_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pdf_url": {
+          "name": "pdf_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_version": {
+          "name": "template_version",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rental_agreement_documents_rental_request_id_idx": {
+          "name": "rental_agreement_documents_rental_request_id_idx",
+          "columns": [
+            {
+              "expression": "rental_request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rental_agreement_documents_rental_request_id_rental_requests_id_fk": {
+          "name": "rental_agreement_documents_rental_request_id_rental_requests_id_fk",
+          "tableFrom": "rental_agreement_documents",
+          "tableTo": "rental_requests",
+          "columnsFrom": ["rental_request_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "rental_agreement_documents_rental_request_id_unique": {
+          "name": "rental_agreement_documents_rental_request_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["rental_request_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rental_payment_lifecycle": {
+      "name": "rental_payment_lifecycle",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "rental_id": {
+          "name": "rental_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rental_charge_id": {
+          "name": "rental_charge_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deposit_hold_status": {
+          "name": "deposit_hold_status",
+          "type": "deposit_hold_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scheduled'"
+        },
+        "deposit_hold_placed_at": {
+          "name": "deposit_hold_placed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deposit_released_at": {
+          "name": "deposit_released_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deposit_captured_at": {
+          "name": "deposit_captured_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_transfer_status": {
+          "name": "owner_transfer_status",
+          "type": "owner_transfer_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "payout_status": {
+          "name": "payout_status",
+          "type": "payout_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "owner_transfer_retry_count": {
+          "name": "owner_transfer_retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "stripe_transfer_id": {
+          "name": "stripe_transfer_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_transferred_at": {
+          "name": "owner_transferred_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rpl_rental_id_idx": {
+          "name": "rpl_rental_id_idx",
+          "columns": [
+            {
+              "expression": "rental_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rpl_payout_status_idx": {
+          "name": "rpl_payout_status_idx",
+          "columns": [
+            {
+              "expression": "payout_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rpl_deposit_hold_status_idx": {
+          "name": "rpl_deposit_hold_status_idx",
+          "columns": [
+            {
+              "expression": "deposit_hold_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rental_payment_lifecycle_rental_id_rentals_id_fk": {
+          "name": "rental_payment_lifecycle_rental_id_rentals_id_fk",
+          "tableFrom": "rental_payment_lifecycle",
+          "tableTo": "rentals",
+          "columnsFrom": ["rental_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rental_requests": {
+      "name": "rental_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "listing_id": {
+          "name": "listing_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "renter_id": {
+          "name": "renter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_days": {
+          "name": "total_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "daily_rate": {
+          "name": "daily_rate",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_amount": {
+          "name": "total_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "security_deposit": {
+          "name": "security_deposit",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "delivery_requested": {
+          "name": "delivery_requested",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "delivery_address": {
+          "name": "delivery_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_instructions": {
+          "name": "delivery_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_fee": {
+          "name": "delivery_fee",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "setup_requested": {
+          "name": "setup_requested",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "setup_fee": {
+          "name": "setup_fee",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "service_fee": {
+          "name": "service_fee",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "application_fee_amount": {
+          "name": "application_fee_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "owner_payout": {
+          "name": "owner_payout",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "platform_net_revenue": {
+          "name": "platform_net_revenue",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_intent_id": {
+          "name": "payment_intent_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_method_id": {
+          "name": "payment_method_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_status": {
+          "name": "payment_status",
+          "type": "payment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'pending'"
+        },
+        "payment_failure_reason": {
+          "name": "payment_failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "security_deposit_auth_id": {
+          "name": "security_deposit_auth_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "rental_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "denied_at": {
+          "name": "denied_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "denial_reason": {
+          "name": "denial_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelled_by": {
+          "name": "cancelled_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancellation_reason": {
+          "name": "cancellation_reason",
+          "type": "cancellation_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancellation_notes": {
+          "name": "cancellation_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rental_requests_listing_id_idx": {
+          "name": "rental_requests_listing_id_idx",
+          "columns": [
+            {
+              "expression": "listing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rental_requests_renter_id_idx": {
+          "name": "rental_requests_renter_id_idx",
+          "columns": [
+            {
+              "expression": "renter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rental_requests_owner_id_idx": {
+          "name": "rental_requests_owner_id_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rental_requests_status_idx": {
+          "name": "rental_requests_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rental_requests_date_range_idx": {
+          "name": "rental_requests_date_range_idx",
+          "columns": [
+            {
+              "expression": "start_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "end_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rental_requests_owner_id_status_idx": {
+          "name": "rental_requests_owner_id_status_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rental_requests_renter_id_status_idx": {
+          "name": "rental_requests_renter_id_status_idx",
+          "columns": [
+            {
+              "expression": "renter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rental_requests_pending_expires_at_idx": {
+          "name": "rental_requests_pending_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "status = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rental_requests_listing_id_listings_id_fk": {
+          "name": "rental_requests_listing_id_listings_id_fk",
+          "tableFrom": "rental_requests",
+          "tableTo": "listings",
+          "columnsFrom": ["listing_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "rental_requests_renter_id_user_id_fk": {
+          "name": "rental_requests_renter_id_user_id_fk",
+          "tableFrom": "rental_requests",
+          "tableTo": "user",
+          "columnsFrom": ["renter_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "rental_requests_owner_id_user_id_fk": {
+          "name": "rental_requests_owner_id_user_id_fk",
+          "tableFrom": "rental_requests",
+          "tableTo": "user",
+          "columnsFrom": ["owner_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "rental_requests_cancelled_by_user_id_fk": {
+          "name": "rental_requests_cancelled_by_user_id_fk",
+          "tableFrom": "rental_requests",
+          "tableTo": "user",
+          "columnsFrom": ["cancelled_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rentals": {
+      "name": "rentals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "listing_id": {
+          "name": "listing_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "renter_id": {
+          "name": "renter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actual_start_date": {
+          "name": "actual_start_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actual_end_date": {
+          "name": "actual_end_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_amount": {
+          "name": "total_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "security_deposit": {
+          "name": "security_deposit",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "setup_requested": {
+          "name": "setup_requested",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "setup_fee": {
+          "name": "setup_fee",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "rental_payment_intent_id": {
+          "name": "rental_payment_intent_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "security_deposit_auth_id": {
+          "name": "security_deposit_auth_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "application_fee_amount": {
+          "name": "application_fee_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pickup_instructions": {
+          "name": "pickup_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "return_instructions": {
+          "name": "return_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "condition_at_pickup": {
+          "name": "condition_at_pickup",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "condition_at_return": {
+          "name": "condition_at_return",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "damage_reported": {
+          "name": "damage_reported",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "damage_description": {
+          "name": "damage_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "damage_photos": {
+          "name": "damage_photos",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "extension_requested": {
+          "name": "extension_requested",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "extension_approved": {
+          "name": "extension_approved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "return_confirmed_at": {
+          "name": "return_confirmed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rentals_request_id_idx": {
+          "name": "rentals_request_id_idx",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rentals_listing_id_idx": {
+          "name": "rentals_listing_id_idx",
+          "columns": [
+            {
+              "expression": "listing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rentals_renter_id_idx": {
+          "name": "rentals_renter_id_idx",
+          "columns": [
+            {
+              "expression": "renter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rentals_owner_id_idx": {
+          "name": "rentals_owner_id_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rentals_date_range_idx": {
+          "name": "rentals_date_range_idx",
+          "columns": [
+            {
+              "expression": "start_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "end_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rentals_return_confirmed_at_idx": {
+          "name": "rentals_return_confirmed_at_idx",
+          "columns": [
+            {
+              "expression": "return_confirmed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rentals_request_id_rental_requests_id_fk": {
+          "name": "rentals_request_id_rental_requests_id_fk",
+          "tableFrom": "rentals",
+          "tableTo": "rental_requests",
+          "columnsFrom": ["request_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "rentals_listing_id_listings_id_fk": {
+          "name": "rentals_listing_id_listings_id_fk",
+          "tableFrom": "rentals",
+          "tableTo": "listings",
+          "columnsFrom": ["listing_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "rentals_renter_id_user_id_fk": {
+          "name": "rentals_renter_id_user_id_fk",
+          "tableFrom": "rentals",
+          "tableTo": "user",
+          "columnsFrom": ["renter_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "rentals_owner_id_user_id_fk": {
+          "name": "rentals_owner_id_user_id_fk",
+          "tableFrom": "rentals",
+          "tableTo": "user",
+          "columnsFrom": ["owner_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "rentals_request_id_unique": {
+          "name": "rentals_request_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["request_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.review_events": {
+      "name": "review_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "entity_kind": {
+          "name": "entity_kind",
+          "type": "review_entity_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "review_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "review_events_entity_kind_entity_id_idx": {
+          "name": "review_events_entity_kind_entity_id_idx",
+          "columns": [
+            {
+              "expression": "entity_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "review_events_entity_kind_event_type_created_at_idx": {
+          "name": "review_events_entity_kind_event_type_created_at_idx",
+          "columns": [
+            {
+              "expression": "entity_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "review_events_actor_user_id_created_at_idx": {
+          "name": "review_events_actor_user_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "actor_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "review_events_created_at_idx": {
+          "name": "review_events_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "review_events_actor_user_id_user_id_fk": {
+          "name": "review_events_actor_user_id_user_id_fk",
+          "tableFrom": "review_events",
+          "tableTo": "user",
+          "columnsFrom": ["actor_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.service_agreement_documents": {
+      "name": "service_agreement_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "service_booking_id": {
+          "name": "service_booking_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pdf_url": {
+          "name": "pdf_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_version": {
+          "name": "template_version",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "service_agreement_documents_service_booking_id_idx": {
+          "name": "service_agreement_documents_service_booking_id_idx",
+          "columns": [
+            {
+              "expression": "service_booking_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "service_agreement_documents_service_booking_id_service_bookings_id_fk": {
+          "name": "service_agreement_documents_service_booking_id_service_bookings_id_fk",
+          "tableFrom": "service_agreement_documents",
+          "tableTo": "service_bookings",
+          "columnsFrom": ["service_booking_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "service_agreement_documents_service_booking_id_unique": {
+          "name": "service_agreement_documents_service_booking_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["service_booking_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.service_payment_lifecycle": {
+      "name": "service_payment_lifecycle",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "booking_id": {
+          "name": "booking_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "charge_id": {
+          "name": "charge_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_payout": {
+          "name": "provider_payout",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_transfer_status": {
+          "name": "owner_transfer_status",
+          "type": "service_owner_transfer_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "payout_status": {
+          "name": "payout_status",
+          "type": "service_payout_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "stripe_transfer_id": {
+          "name": "stripe_transfer_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_transferred_at": {
+          "name": "owner_transferred_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transfer_amount": {
+          "name": "transfer_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "spl_booking_id_idx": {
+          "name": "spl_booking_id_idx",
+          "columns": [
+            {
+              "expression": "booking_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "spl_payout_status_idx": {
+          "name": "spl_payout_status_idx",
+          "columns": [
+            {
+              "expression": "payout_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "spl_owner_transfer_status_idx": {
+          "name": "spl_owner_transfer_status_idx",
+          "columns": [
+            {
+              "expression": "owner_transfer_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "service_payment_lifecycle_booking_id_service_bookings_id_fk": {
+          "name": "service_payment_lifecycle_booking_id_service_bookings_id_fk",
+          "tableFrom": "service_payment_lifecycle",
+          "tableTo": "service_bookings",
+          "columnsFrom": ["booking_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.service_bookings": {
+      "name": "service_bookings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "listing_id": {
+          "name": "listing_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requester_id": {
+          "name": "requester_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "community_id": {
+          "name": "community_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposed_date": {
+          "name": "proposed_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposed_time": {
+          "name": "proposed_time",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hours": {
+          "name": "hours",
+          "type": "numeric(4, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decline_reason": {
+          "name": "decline_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "service_price": {
+          "name": "service_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service_fee": {
+          "name": "service_fee",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_amount": {
+          "name": "total_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "service_booking_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "stripe_payment_intent_id": {
+          "name": "stripe_payment_intent_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_charge_id": {
+          "name": "stripe_charge_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_status": {
+          "name": "payment_status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refund_amount": {
+          "name": "refund_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_refund_id": {
+          "name": "stripe_refund_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelled_by": {
+          "name": "cancelled_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancellation_reason": {
+          "name": "cancellation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_payment_method_id": {
+          "name": "selected_payment_method_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sb_completed_at_idx": {
+          "name": "sb_completed_at_idx",
+          "columns": [
+            {
+              "expression": "completed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sb_provider_idx": {
+          "name": "sb_provider_idx",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sb_requester_idx": {
+          "name": "sb_requester_idx",
+          "columns": [
+            {
+              "expression": "requester_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sb_pending_expires_at_idx": {
+          "name": "sb_pending_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "status = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "service_bookings_listing_id_service_listings_id_fk": {
+          "name": "service_bookings_listing_id_service_listings_id_fk",
+          "tableFrom": "service_bookings",
+          "tableTo": "service_listings",
+          "columnsFrom": ["listing_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "service_bookings_requester_id_user_id_fk": {
+          "name": "service_bookings_requester_id_user_id_fk",
+          "tableFrom": "service_bookings",
+          "tableTo": "user",
+          "columnsFrom": ["requester_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "service_bookings_provider_id_user_id_fk": {
+          "name": "service_bookings_provider_id_user_id_fk",
+          "tableFrom": "service_bookings",
+          "tableTo": "user",
+          "columnsFrom": ["provider_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "service_bookings_community_id_communities_id_fk": {
+          "name": "service_bookings_community_id_communities_id_fk",
+          "tableFrom": "service_bookings",
+          "tableTo": "communities",
+          "columnsFrom": ["community_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "service_bookings_cancelled_by_user_id_fk": {
+          "name": "service_bookings_cancelled_by_user_id_fk",
+          "tableFrom": "service_bookings",
+          "tableTo": "user",
+          "columnsFrom": ["cancelled_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.service_listing_categories": {
+      "name": "service_listing_categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "service_listing_categories_name_unique": {
+          "name": "service_listing_categories_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.service_listings": {
+      "name": "service_listings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "community_id": {
+          "name": "community_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pricing_type": {
+          "name": "pricing_type",
+          "type": "service_pricing_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "photos": {
+          "name": "photos",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "service_notes": {
+          "name": "service_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_policies_acknowledged": {
+          "name": "owner_policies_acknowledged",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "service_listing_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending_approval'"
+        },
+        "admin_note": {
+          "name": "admin_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sl_community_status_idx": {
+          "name": "sl_community_status_idx",
+          "columns": [
+            {
+              "expression": "community_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sl_provider_idx": {
+          "name": "sl_provider_idx",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sl_category_idx": {
+          "name": "sl_category_idx",
+          "columns": [
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "service_listings_community_id_communities_id_fk": {
+          "name": "service_listings_community_id_communities_id_fk",
+          "tableFrom": "service_listings",
+          "tableTo": "communities",
+          "columnsFrom": ["community_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "service_listings_provider_id_user_id_fk": {
+          "name": "service_listings_provider_id_user_id_fk",
+          "tableFrom": "service_listings",
+          "tableTo": "user",
+          "columnsFrom": ["provider_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "service_listings_category_id_service_listing_categories_id_fk": {
+          "name": "service_listings_category_id_service_listing_categories_id_fk",
+          "tableFrom": "service_listings",
+          "tableTo": "service_listing_categories",
+          "columnsFrom": ["category_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.service_provider_profiles": {
+      "name": "service_provider_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aggregate_rating": {
+          "name": "aggregate_rating",
+          "type": "numeric(3, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_count": {
+          "name": "review_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "service_provider_profiles_user_id_user_id_fk": {
+          "name": "service_provider_profiles_user_id_user_id_fk",
+          "tableFrom": "service_provider_profiles",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "service_provider_profiles_user_id_unique": {
+          "name": "service_provider_profiles_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_activity_log": {
+      "name": "user_activity_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "user_activity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_activity_log_user_id_created_at_idx": {
+          "name": "user_activity_log_user_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_activity_log_created_at_idx": {
+          "name": "user_activity_log_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_activity_log_user_id_user_id_fk": {
+          "name": "user_activity_log_user_id_user_id_fk",
+          "tableFrom": "user_activity_log",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "user_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending_verification'"
+        },
+        "user_type": {
+          "name": "user_type",
+          "type": "user_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'standard'"
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_image_url": {
+          "name": "profile_image_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_connected_account_id": {
+          "name": "stripe_connected_account_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connect_onboarding_complete": {
+          "name": "connect_onboarding_complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "connect_charges_enabled": {
+          "name": "connect_charges_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "connect_payouts_enabled": {
+          "name": "connect_payouts_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "id_verified": {
+          "name": "id_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "address_verified": {
+          "name": "address_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_login_at": {
+          "name": "last_login_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_aggregate_rating": {
+          "name": "review_aggregate_rating",
+          "type": "numeric(3, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_count": {
+          "name": "review_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "tos_version": {
+          "name": "tos_version",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tos_accepted_at": {
+          "name": "tos_accepted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "privacy_version": {
+          "name": "privacy_version",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "privacy_accepted_at": {
+          "name": "privacy_accepted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "community_version": {
+          "name": "community_version",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "community_accepted_at": {
+          "name": "community_accepted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_last_active_at_idx": {
+          "name": "user_last_active_at_idx",
+          "columns": [
+            {
+              "expression": "last_active_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_addresses": {
+      "name": "user_addresses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "street": {
+          "name": "street",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "city": {
+          "name": "city",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "zip_code": {
+          "name": "zip_code",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country": {
+          "name": "country",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'US'"
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "numeric(10, 8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "numeric(11, 8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_addresses_user_id_idx": {
+          "name": "user_addresses_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_addresses_location_idx": {
+          "name": "user_addresses_location_idx",
+          "columns": [
+            {
+              "expression": "latitude",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "longitude",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_addresses_user_id_user_id_fk": {
+          "name": "user_addresses_user_id_user_id_fk",
+          "tableFrom": "user_addresses",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_payment_methods": {
+      "name": "user_payment_methods",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_payment_method_id": {
+          "name": "stripe_payment_method_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last4": {
+          "name": "last4",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "brand": {
+          "name": "brand",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiry_month": {
+          "name": "expiry_month",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiry_year": {
+          "name": "expiry_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_payment_methods_user_id_idx": {
+          "name": "user_payment_methods_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_payment_methods_stripe_idx": {
+          "name": "user_payment_methods_stripe_idx",
+          "columns": [
+            {
+              "expression": "stripe_payment_method_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_payment_methods_user_id_user_id_fk": {
+          "name": "user_payment_methods_user_id_user_id_fk",
+          "tableFrom": "user_payment_methods",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_preferences": {
+      "name": "user_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_notifications": {
+          "name": "email_notifications",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sms_notifications": {
+          "name": "sms_notifications",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "push_notifications": {
+          "name": "push_notifications",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "marketing_emails": {
+          "name": "marketing_emails",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "lending_radius": {
+          "name": "lending_radius",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "auto_approve_requests": {
+          "name": "auto_approve_requests",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "weekend_availability": {
+          "name": "weekend_availability",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "default_rental_period": {
+          "name": "default_rental_period",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 3
+        },
+        "public_profile": {
+          "name": "public_profile",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "show_location": {
+          "name": "show_location",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "show_activity_status": {
+          "name": "show_activity_status",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "analytics_tracking": {
+          "name": "analytics_tracking",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "language": {
+          "name": "language",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en'"
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'America/Chicago'"
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'USD'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_preferences_user_id_user_id_fk": {
+          "name": "user_preferences_user_id_user_id_fk",
+          "tableFrom": "user_preferences",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_preferences_user_id_unique": {
+          "name": "user_preferences_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.approval_status": {
+      "name": "approval_status",
+      "schema": "public",
+      "values": ["pending_review", "approved", "rejected"]
+    },
+    "public.audit_action_type": {
+      "name": "audit_action_type",
+      "schema": "public",
+      "values": [
+        "dispute_created",
+        "state_change",
+        "evidence_uploaded",
+        "evidence_deleted",
+        "financial_operation",
+        "note_created",
+        "note_updated",
+        "note_deleted",
+        "resolution"
+      ]
+    },
+    "public.cancellation_reason": {
+      "name": "cancellation_reason",
+      "schema": "public",
+      "values": [
+        "renter_cancellation",
+        "owner_cancellation",
+        "renter_no_show",
+        "owner_no_show",
+        "expired_no_acceptance"
+      ]
+    },
+    "public.deposit_hold_status": {
+      "name": "deposit_hold_status",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "held",
+        "released",
+        "expired",
+        "release_failed",
+        "failed",
+        "captured",
+        "not_applicable"
+      ]
+    },
+    "public.dispute_reason_code": {
+      "name": "dispute_reason_code",
+      "schema": "public",
+      "values": [
+        "damage",
+        "non_delivery",
+        "quality_issue",
+        "cancellation",
+        "payment_issue",
+        "renter_no_show",
+        "owner_no_show",
+        "requester_no_show",
+        "provider_no_show",
+        "other"
+      ]
+    },
+    "public.dispute_resolution_outcome": {
+      "name": "dispute_resolution_outcome",
+      "schema": "public",
+      "values": [
+        "favor_renter",
+        "favor_provider",
+        "partial_renter",
+        "partial_provider",
+        "dismissed"
+      ]
+    },
+    "public.dispute_role": {
+      "name": "dispute_role",
+      "schema": "public",
+      "values": ["renter", "owner", "provider", "requester"]
+    },
+    "public.dispute_status": {
+      "name": "dispute_status",
+      "schema": "public",
+      "values": [
+        "open",
+        "evidence_requested",
+        "under_review",
+        "resolved",
+        "closed"
+      ]
+    },
+    "public.evidence_type": {
+      "name": "evidence_type",
+      "schema": "public",
+      "values": ["image", "text"]
+    },
+    "public.financial_operation_status": {
+      "name": "financial_operation_status",
+      "schema": "public",
+      "values": ["pending", "succeeded", "failed"]
+    },
+    "public.financial_operation_type": {
+      "name": "financial_operation_type",
+      "schema": "public",
+      "values": [
+        "hold_payout",
+        "refund_partial",
+        "refund_full",
+        "capture_deposit"
+      ]
+    },
+    "public.listing_status": {
+      "name": "listing_status",
+      "schema": "public",
+      "values": ["available", "rented", "maintenance", "inactive"]
+    },
+    "public.message_status": {
+      "name": "message_status",
+      "schema": "public",
+      "values": ["sent", "delivered", "read"]
+    },
+    "public.notification_category": {
+      "name": "notification_category",
+      "schema": "public",
+      "values": ["bookings", "payments", "messages", "disputes", "reminders"]
+    },
+    "public.notification_type": {
+      "name": "notification_type",
+      "schema": "public",
+      "values": [
+        "rental_request_created",
+        "rental_approved",
+        "rental_denied",
+        "rental_started",
+        "rental_ended",
+        "rental_cancelled",
+        "rental_overdue",
+        "rental_reminder",
+        "payment_succeeded",
+        "payment_failed",
+        "payment_refunded",
+        "review_received",
+        "message_received",
+        "listing_approved",
+        "listing_rejected",
+        "system",
+        "dispute_created",
+        "dispute_evidence_requested",
+        "dispute_evidence_deadline_approaching",
+        "dispute_evidence_deadline_expired",
+        "dispute_resolved",
+        "re_engagement",
+        "service_booking_requested",
+        "service_booking_accepted",
+        "service_booking_declined",
+        "service_booking_completed",
+        "service_payout_sent",
+        "service_listing_approved",
+        "service_listing_rejected",
+        "service_listing_pending",
+        "listing_pending_review",
+        "review_submitted",
+        "admin_dispute_created"
+      ]
+    },
+    "public.owner_transfer_status": {
+      "name": "owner_transfer_status",
+      "schema": "public",
+      "values": ["pending", "processing", "completed", "failed", "frozen"]
+    },
+    "public.payment_status": {
+      "name": "payment_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "processing",
+        "succeeded",
+        "completed",
+        "failed",
+        "refunded"
+      ]
+    },
+    "public.payment_type": {
+      "name": "payment_type",
+      "schema": "public",
+      "values": ["rental_charge", "security_deposit_hold", "service_charge"]
+    },
+    "public.payout_status": {
+      "name": "payout_status",
+      "schema": "public",
+      "values": ["pending", "processing", "completed", "failed"]
+    },
+    "public.push_subscription_platform": {
+      "name": "push_subscription_platform",
+      "schema": "public",
+      "values": ["web", "ios", "android"]
+    },
+    "public.rental_status": {
+      "name": "rental_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "active",
+        "completed",
+        "cancelled",
+        "overdue",
+        "denied"
+      ]
+    },
+    "public.review_entity_kind": {
+      "name": "review_entity_kind",
+      "schema": "public",
+      "values": ["service_listing", "tool_listing"]
+    },
+    "public.review_event_type": {
+      "name": "review_event_type",
+      "schema": "public",
+      "values": ["provider_resubmitted", "rejected", "approved"]
+    },
+    "public.service_booking_status": {
+      "name": "service_booking_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "accepted",
+        "declined",
+        "payment_failed",
+        "completed",
+        "cancelled"
+      ]
+    },
+    "public.service_listing_status": {
+      "name": "service_listing_status",
+      "schema": "public",
+      "values": ["pending_approval", "active", "inactive", "denied"]
+    },
+    "public.service_owner_transfer_status": {
+      "name": "service_owner_transfer_status",
+      "schema": "public",
+      "values": ["pending", "processing", "completed", "failed", "frozen"]
+    },
+    "public.service_payout_status": {
+      "name": "service_payout_status",
+      "schema": "public",
+      "values": ["pending", "processing", "completed", "failed"]
+    },
+    "public.service_pricing_type": {
+      "name": "service_pricing_type",
+      "schema": "public",
+      "values": ["fixed", "hourly"]
+    },
+    "public.user_activity_type": {
+      "name": "user_activity_type",
+      "schema": "public",
+      "values": [
+        "login",
+        "logout",
+        "password_change",
+        "listing_created",
+        "listing_updated",
+        "listing_deleted",
+        "listing_published",
+        "rental_requested",
+        "rental_approved",
+        "rental_rejected",
+        "rental_completed",
+        "rental_cancelled",
+        "profile_updated",
+        "settings_updated",
+        "payment_made",
+        "payout_received",
+        "review_created",
+        "review_responded"
+      ]
+    },
+    "public.user_status": {
+      "name": "user_status",
+      "schema": "public",
+      "values": [
+        "pending_verification",
+        "email_verified",
+        "incomplete_profile",
+        "active",
+        "inactive",
+        "suspended"
+      ]
+    },
+    "public.user_type": {
+      "name": "user_type",
+      "schema": "public",
+      "values": ["standard", "admin", "superadmin"]
+    },
+    "public.verification_status": {
+      "name": "verification_status",
+      "schema": "public",
+      "values": ["pending", "verified", "denied"]
+    },
+    "public.community_membership_role": {
+      "name": "community_membership_role",
+      "schema": "public",
+      "values": ["admin", "member"]
+    },
+    "public.delivery_mode": {
+      "name": "delivery_mode",
+      "schema": "public",
+      "values": ["pickup_only", "delivery_only", "both_available"]
+    },
+    "public.listing_condition": {
+      "name": "listing_condition",
+      "schema": "public",
+      "values": ["new", "good", "fair", "poor"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -435,6 +435,13 @@
       "when": 1778803200000,
       "tag": "0061_attach_verona_hills_to_kc_metro",
       "breakpoints": true
+    },
+    {
+      "idx": 62,
+      "version": "7",
+      "when": 1779038318312,
+      "tag": "0062_strong_screwball",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schemas/_enums.ts
+++ b/src/db/schemas/_enums.ts
@@ -240,6 +240,7 @@ export const cancellationReasonEnum = pgEnum("cancellation_reason", [
   "owner_cancellation", // Owner cancelled after approval
   "renter_no_show", // Renter did not show up — ops-applied
   "owner_no_show", // Owner did not show up — ops-applied
+  "expired_no_acceptance", // Owner never responded; cron auto-expired the pending request
 ]);
 
 export const serviceListingStatusEnum = pgEnum("service_listing_status", [

--- a/src/db/schemas/rentals.schema.ts
+++ b/src/db/schemas/rentals.schema.ts
@@ -19,7 +19,7 @@ import {
   paymentStatusEnum,
   cancellationReasonEnum,
 } from "./_enums";
-import { relations } from "drizzle-orm";
+import { relations, sql } from "drizzle-orm";
 import { payments } from "./payments.schema";
 
 // Rental requests
@@ -86,6 +86,13 @@ export const rentalRequests = pgTable(
     cancelledBy: text("cancelled_by").references(() => user.id),
     cancellationReason: cancellationReasonEnum("cancellation_reason"),
     cancellationNotes: text("cancellation_notes"),
+    /**
+     * Hard deadline for a pending request. After this time, the cron at
+     * /api/cron/expire-pending-bookings transitions the row to `cancelled` with
+     * cancellationReason='expired_no_acceptance'. Set at insert time to
+     * createdAt + PENDING_BOOKING_EXPIRY_WINDOW_HOURS.
+     */
+    expiresAt: timestamp("expires_at").notNull(),
     createdAt: timestamp("created_at").defaultNow().notNull(),
     updatedAt: timestamp("updated_at").defaultNow().notNull(),
   },
@@ -106,6 +113,9 @@ export const rentalRequests = pgTable(
       table.renterId,
       table.status,
     ),
+    pendingExpiresAtIdx: index("rental_requests_pending_expires_at_idx")
+      .on(table.expiresAt)
+      .where(sql`status = 'pending'`),
   }),
 );
 

--- a/src/db/schemas/services.schema.ts
+++ b/src/db/schemas/services.schema.ts
@@ -11,7 +11,7 @@ import {
   index,
   boolean,
 } from "drizzle-orm/pg-core";
-import { relations } from "drizzle-orm";
+import { relations, sql } from "drizzle-orm";
 
 import {
   serviceBookingStatusEnum,
@@ -112,6 +112,13 @@ export const serviceBookings = pgTable(
     selectedPaymentMethodId: varchar("selected_payment_method_id", {
       length: 255,
     }),
+    /**
+     * Hard deadline for a pending booking. After this time, the cron at
+     * /api/cron/expire-pending-bookings transitions the row to `cancelled` with
+     * cancellationReason='expired_no_acceptance'. Set at insert time to
+     * createdAt + PENDING_BOOKING_EXPIRY_WINDOW_HOURS.
+     */
+    expiresAt: timestamp("expires_at").notNull(),
     createdAt: timestamp("created_at").defaultNow().notNull(),
     updatedAt: timestamp("updated_at").defaultNow().notNull(),
   },
@@ -119,6 +126,9 @@ export const serviceBookings = pgTable(
     completedAtIdx: index("sb_completed_at_idx").on(table.completedAt),
     providerIdx: index("sb_provider_idx").on(table.providerId),
     requesterIdx: index("sb_requester_idx").on(table.requesterId),
+    pendingExpiresAtIdx: index("sb_pending_expires_at_idx")
+      .on(table.expiresAt)
+      .where(sql`status = 'pending'`),
   }),
 );
 

--- a/src/db/seeds/rentals.seed.ts
+++ b/src/db/seeds/rentals.seed.ts
@@ -219,6 +219,7 @@ async function main(): Promise<void> {
           : null,
       createdAt: dates.createdAt,
       updatedAt: new Date(),
+      expiresAt: new Date(dates.createdAt.getTime() + 72 * 60 * 60 * 1000),
     };
 
     seedRequests.push(request);

--- a/src/features/dashboard/lib/__tests__/schedule.test.ts
+++ b/src/features/dashboard/lib/__tests__/schedule.test.ts
@@ -126,6 +126,7 @@ describe("getUpcomingSchedule", () => {
         selectedPaymentMethodId: null,
         createdAt: new Date(),
         updatedAt: new Date(),
+        expiresAt: new Date(Date.now() + 72 * 60 * 60 * 1000),
         listingTitle: "Lawn care",
         counterparty: {
           id: "prov-1",
@@ -164,6 +165,7 @@ describe("getUpcomingSchedule", () => {
         selectedPaymentMethodId: null,
         createdAt: new Date(),
         updatedAt: new Date(),
+        expiresAt: new Date(Date.now() + 72 * 60 * 60 * 1000),
         listingTitle: "Gutter clean",
         counterparty: {
           id: "req-1",

--- a/src/features/listings/hooks/__tests__/use-listing-form-submit.test.tsx
+++ b/src/features/listings/hooks/__tests__/use-listing-form-submit.test.tsx
@@ -168,7 +168,9 @@ describe("useListingFormSubmit", () => {
         "Listing and images uploaded successfully!",
       );
       expect(mockOnSuccess).toHaveBeenCalled();
-      expect(mockPush).toHaveBeenCalledWith("/dashboard/listings/rentals");
+      expect(mockPush).toHaveBeenCalledWith(
+        "/dashboard/listings/rentals?tab=pending_review",
+      );
     });
 
     it("should handle missing listingId from create response", async () => {

--- a/src/features/listings/hooks/use-listing-form-submit.ts
+++ b/src/features/listings/hooks/use-listing-form-submit.ts
@@ -160,11 +160,11 @@ export function useListingFormSubmit({
               `${uploadResult.succeeded} of ${uploadResult.total} images uploaded. You can add more from the edit page.`,
             );
             onSuccess?.();
-            router.push("/dashboard/listings/rentals");
+            router.push("/dashboard/listings/rentals?tab=pending_review");
           } else {
             toast.success("Listing and images uploaded successfully!");
             onSuccess?.();
-            router.push("/dashboard/listings/rentals");
+            router.push("/dashboard/listings/rentals?tab=pending_review");
           }
         }
       } catch (error) {

--- a/src/features/listings/services/__tests__/listing-service.test.ts
+++ b/src/features/listings/services/__tests__/listing-service.test.ts
@@ -3,11 +3,19 @@ import { ListingService } from "../listing-service";
 import { NotFoundError, ForbiddenError, ValidationError } from "@/dal/errors";
 import type { CreateListingFormDataServerType } from "@/features/listings/form-schema/listing.schema";
 
+const { mockLogGatingEvent } = vi.hoisted(() => ({
+  mockLogGatingEvent: vi.fn(),
+}));
+
+vi.mock("@/features/payments/lib/log-events", () => ({
+  logGatingEvent: mockLogGatingEvent,
+}));
+
 const mockGetListingById = vi.fn();
 const mockUpdateListing = vi.fn();
 const mockDeleteListing = vi.fn();
 const mockCreateListing = vi.fn();
-const mockIsConnectOnboardingComplete = vi.fn();
+const mockGetUserById = vi.fn();
 const mockRequireUserCommunityMembership = vi.fn();
 const mockGetAllCurrentVersions = vi.fn();
 const mockRecordAcceptance = vi.fn();
@@ -40,8 +48,7 @@ vi.mock("@/dal", () => ({
     createListing: (...args: unknown[]) => mockCreateListing(...args),
   },
   userDAL: {
-    isConnectOnboardingComplete: (...args: unknown[]) =>
-      mockIsConnectOnboardingComplete(...args),
+    getUserById: (...args: unknown[]) => mockGetUserById(...args),
   },
   communityDAL: {
     requireUserCommunityMembership: (...args: unknown[]) =>
@@ -126,7 +133,13 @@ describe("ListingService", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockGetListingById.mockResolvedValue(mockListing);
-    mockIsConnectOnboardingComplete.mockResolvedValue(true);
+    mockGetUserById.mockResolvedValue({
+      id: "user-1",
+      stripeConnectedAccountId: "acct_123",
+      connectChargesEnabled: true,
+      connectPayoutsEnabled: true,
+      connectOnboardingComplete: true,
+    });
     mockRequireUserCommunityMembership.mockResolvedValue({
       community: { id: "community-1" },
     });
@@ -138,17 +151,31 @@ describe("ListingService", () => {
   });
 
   describe("createListing", () => {
-    it("throws ValidationError when Stripe Connect onboarding is incomplete", async () => {
-      mockIsConnectOnboardingComplete.mockResolvedValue(false);
+    it("creates the listing and emits listing_created_without_stripe_connect when Connect is incomplete", async () => {
+      mockGetUserById.mockResolvedValue({
+        id: "user-1",
+        stripeConnectedAccountId: null,
+        connectChargesEnabled: false,
+        connectPayoutsEnabled: false,
+        connectOnboardingComplete: false,
+      });
 
-      await expect(
-        ListingService.createListing(minimalListingPayload, "user-1", {
-          ipAddress: "127.0.0.1",
-          userAgent: "vitest",
+      const result = await ListingService.createListing(
+        minimalListingPayload,
+        "user-1",
+        { ipAddress: "127.0.0.1", userAgent: "vitest" },
+      );
+
+      expect(result.listingId).toBe("listing-new");
+      expect(mockCreateListing).toHaveBeenCalled();
+      expect(mockLogGatingEvent).toHaveBeenCalledWith(
+        "listing_created_without_stripe_connect",
+        expect.objectContaining({
+          userId: "user-1",
+          listingId: "listing-new",
+          onboardingStatus: "not_started",
         }),
-      ).rejects.toThrow(ValidationError);
-
-      expect(mockCreateListing).not.toHaveBeenCalled();
+      );
     });
 
     it("creates listing, tracks activity, and notifies admins on success", async () => {

--- a/src/features/listings/services/listing-service.ts
+++ b/src/features/listings/services/listing-service.ts
@@ -1,5 +1,4 @@
 import { eq, max, count } from "drizzle-orm";
-import { tryCatch } from "@walkup/walkup-utils";
 
 import { db } from "@/db/db";
 import { listingImages } from "@/db/schemas/listings.schema";
@@ -16,6 +15,8 @@ import {
 import { trackActivity } from "@/features/activity/lib/track-activity";
 import { sendRentalListingPendingAdminNotification } from "@/features/listings/notifications/listing-pending-review";
 import type { CreateListingFormDataServerType } from "@/features/listings/form-schema/listing.schema";
+import { getPayoutReadiness } from "@/features/payments/lib/payout-readiness";
+import { logGatingEvent } from "@/features/payments/lib/log-events";
 
 const MAX_IMAGES_PER_LISTING = 10;
 
@@ -152,30 +153,21 @@ export class ListingService {
   }
 
   /**
-   * Creates a rental listing after Stripe Connect and community checks,
-   * records activity, notifies admins, and records legal document acceptances.
+   * Creates a rental listing after community membership check, records activity,
+   * notifies admins, and records legal document acceptances. Stripe Connect is
+   * NOT required at this stage; it is enforced just-in-time at booking acceptance.
    *
    * @param validatedData - Server-validated listing form payload
    * @param userId - Authenticated owner user id
    * @param context - IP and user agent for legal acceptance records
    * @returns The new listing id
-   * @throws ValidationError if Connect onboarding is incomplete or community membership is missing
+   * @throws ValidationError if community membership is missing
    */
   static async createListing(
     validatedData: CreateListingFormDataServerType,
     userId: string,
     context: ListingCreationContext,
   ): Promise<{ listingId: string }> {
-    const { data: isOnboarded, error: onboardingError } = await tryCatch(
-      userDAL.isConnectOnboardingComplete(userId),
-    );
-
-    if (onboardingError || !isOnboarded) {
-      throw new ValidationError(
-        "Complete Stripe onboarding first. You need to set up payments before creating listings.",
-      );
-    }
-
     const userCommunityInfo =
       await communityDAL.requireUserCommunityMembership(userId);
 
@@ -187,6 +179,21 @@ export class ListingService {
 
     if (!listing) {
       throw new Error("Failed to create listing");
+    }
+
+    const user = await userDAL.getUserById(userId);
+    const readiness = getPayoutReadiness({
+      stripeConnectedAccountId: user.stripeConnectedAccountId ?? null,
+      connectChargesEnabled: user.connectChargesEnabled,
+      connectPayoutsEnabled: user.connectPayoutsEnabled,
+      connectOnboardingComplete: user.connectOnboardingComplete,
+    });
+    if (readiness.onboardingStatus !== "verified") {
+      logGatingEvent("listing_created_without_stripe_connect", {
+        userId,
+        listingId: listing.id,
+        onboardingStatus: readiness.onboardingStatus,
+      });
     }
 
     trackActivity(userId, "listing_created", { listingId: listing.id });

--- a/src/features/payments/components/__tests__/payout-readiness-banner.test.tsx
+++ b/src/features/payments/components/__tests__/payout-readiness-banner.test.tsx
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import type { ReactNode } from "react";
+
+import { PayoutReadinessBanner } from "../payout-readiness-banner";
+
+vi.mock("next/link", () => ({
+  default: ({ children, href }: { children: ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+const DISMISS_KEY = "payout-readiness-banner-dismissed";
+
+describe("PayoutReadinessBanner", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  it("renders not_started copy and Connect CTA", () => {
+    render(<PayoutReadinessBanner onboardingStatus="not_started" />);
+    expect(
+      screen.getByText(
+        "Connect your payout account so you can accept bookings the moment a request comes in.",
+      ),
+    ).toBeInTheDocument();
+    const cta = screen.getByRole("link", { name: "Connect now" });
+    expect(cta).toHaveAttribute(
+      "href",
+      "/dashboard/payments/earnings-and-payouts",
+    );
+  });
+
+  it("renders pending copy and Finish setup CTA", () => {
+    render(<PayoutReadinessBanner onboardingStatus="pending" />);
+    expect(
+      screen.getByText(
+        "Finish setting up your payout account to accept bookings.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "Finish setup" }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders restricted copy and Update CTA", () => {
+    render(<PayoutReadinessBanner onboardingStatus="restricted" />);
+    expect(
+      screen.getByText(
+        "Your payout account needs an update. Bookings can't be accepted until this is fixed.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "Update now" }),
+    ).toBeInTheDocument();
+  });
+
+  it("hides itself and writes sessionStorage flag when dismissed", () => {
+    render(<PayoutReadinessBanner onboardingStatus="pending" />);
+    const dismiss = screen.getByRole("button", {
+      name: "Dismiss payout setup reminder",
+    });
+    fireEvent.click(dismiss);
+    expect(
+      screen.queryByText(
+        "Finish setting up your payout account to accept bookings.",
+      ),
+    ).not.toBeInTheDocument();
+    expect(sessionStorage.getItem(DISMISS_KEY)).toBe("1");
+  });
+
+  it("does not render when the dismissal flag is already set in sessionStorage", () => {
+    sessionStorage.setItem(DISMISS_KEY, "1");
+    render(<PayoutReadinessBanner onboardingStatus="not_started" />);
+    expect(
+      screen.queryByText(
+        "Connect your payout account so you can accept bookings the moment a request comes in.",
+      ),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/features/payments/components/connect-onboarding.tsx
+++ b/src/features/payments/components/connect-onboarding.tsx
@@ -39,9 +39,24 @@ const ONBOARDING_TIPS: OnboardingTip[] = [
 
 interface ConnectOnboardingProps {
   onComplete?: () => void;
+  /** Card title; defaults to "Set up payouts to start earning". */
+  heading?: string;
+  /** Card description; defaults to "Secure Stripe setup. Takes ~2 minutes.". */
+  description?: string;
+  /**
+   * When true, the completion call tells the server the user arrived from the
+   * just-in-time accept flow so it can emit a `connect_onboarding_completed_from_accept`
+   * log event. Defaults to false (regular dashboard onboarding).
+   */
+  fromJitAccept?: boolean;
 }
 
-export function ConnectOnboarding({ onComplete }: ConnectOnboardingProps) {
+export function ConnectOnboarding({
+  onComplete,
+  heading,
+  description,
+  fromJitAccept,
+}: ConnectOnboardingProps) {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [connectInstance, setConnectInstance] =
@@ -102,6 +117,10 @@ export function ConnectOnboarding({ onComplete }: ConnectOnboardingProps) {
     try {
       const response = await fetch("/api/stripe/update-onboarding-status", {
         method: "POST",
+        ...(fromJitAccept && {
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ fromJitAccept: true }),
+        }),
       });
 
       if (!response.ok) {
@@ -155,9 +174,9 @@ export function ConnectOnboarding({ onComplete }: ConnectOnboardingProps) {
     <>
       <Card>
         <CardHeader>
-          <CardTitle>Set up payouts to start earning</CardTitle>
+          <CardTitle>{heading ?? "Set up payouts to start earning"}</CardTitle>
           <CardDescription>
-            Secure Stripe setup. Takes ~2 minutes.
+            {description ?? "Secure Stripe setup. Takes ~2 minutes."}
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">

--- a/src/features/payments/components/earnings-and-payouts-page-client.tsx
+++ b/src/features/payments/components/earnings-and-payouts-page-client.tsx
@@ -1,14 +1,17 @@
 "use client";
 
 import { useEffect, useState, useRef } from "react";
+import { useRouter } from "next/navigation";
 import { loadConnectAndInitialize } from "@stripe/connect-js";
 import { ConnectComponentsProvider } from "@stripe/react-connect-js";
 import type { StripeConnectInstance } from "@stripe/connect-js";
 import { PaymentsPageError } from "./payments-page-error";
 import { OwnerSection } from "./owner-section";
 import { InitiateStripeOnboarding } from "./initiate-stripe-onboarding";
+import { ConnectOnboarding } from "./connect-onboarding";
 import { useAccountSession } from "../hooks/use-stripe-connect";
 import { PaymentExplainerSection } from "./payment-explainer-section";
+import type { OnboardingStatus } from "../lib/payout-readiness";
 
 const STRIPE_PUBLISHABLE_KEY = process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY;
 
@@ -18,15 +21,89 @@ if (!STRIPE_PUBLISHABLE_KEY) {
 
 interface EarningsAndPayoutsPageClientProps {
   isOnboarded: boolean;
+  /** Validated dashboard path to navigate to after JIT onboarding completes. */
+  returnTo?: string;
+  /** Derived readiness from the server; required when `returnTo` is set. */
+  onboardingStatus?: OnboardingStatus;
 }
 
+/** JIT-mode copy variants by readiness state. */
+const JIT_COPY: Record<
+  Exclude<OnboardingStatus, "verified">,
+  { heading: string; description: string }
+> = {
+  not_started: {
+    heading: "Connect your payout account to accept this booking",
+    description:
+      "Add a bank account so you can get paid. We use Stripe to keep your info secure.",
+  },
+  pending: {
+    heading: "Finish connecting your payout account",
+    description: "A few more details and you're ready to accept bookings.",
+  },
+  restricted: {
+    heading: "Your payout account needs more information",
+    description:
+      "Stripe needs an update before bookings can be accepted on your account.",
+  },
+};
+
 /**
- * Client component for the earnings and payouts page
- * Handles Stripe Connect initialization and renders owner section
+ * Client component for the earnings and payouts page.
+ * Dispatches to the JIT onboarding view when arriving from the accept flow,
+ * otherwise renders the full earnings dashboard.
  */
 export function EarningsAndPayoutsPageClient({
   isOnboarded,
+  returnTo,
+  onboardingStatus,
 }: EarningsAndPayoutsPageClientProps) {
+  if (returnTo) {
+    return (
+      <JitOnboardingView
+        returnTo={returnTo}
+        onboardingStatus={onboardingStatus}
+      />
+    );
+  }
+  return <EarningsAndPayoutsDashboardView isOnboarded={isOnboarded} />;
+}
+
+/**
+ * JIT mode: render only the onboarding form with context copy. On completion,
+ * navigate to the originating booking.
+ */
+function JitOnboardingView({
+  returnTo,
+  onboardingStatus,
+}: {
+  returnTo: string;
+  onboardingStatus?: OnboardingStatus;
+}) {
+  const router = useRouter();
+  const status =
+    onboardingStatus && onboardingStatus !== "verified"
+      ? onboardingStatus
+      : "not_started";
+  const copy = JIT_COPY[status];
+  return (
+    <ConnectOnboarding
+      heading={copy.heading}
+      description={copy.description}
+      fromJitAccept
+      onComplete={() => router.push(returnTo)}
+    />
+  );
+}
+
+/**
+ * Default dashboard view — Stripe Connect initialization plus the owner section.
+ */
+function EarningsAndPayoutsDashboardView({
+  isOnboarded,
+}: {
+  isOnboarded: boolean;
+}) {
   const [connectInstance, setConnectInstance] =
     useState<StripeConnectInstance | null>(null);
   const [initError, setInitError] = useState<string | null>(null);

--- a/src/features/payments/components/payout-readiness-banner-server.tsx
+++ b/src/features/payments/components/payout-readiness-banner-server.tsx
@@ -1,0 +1,29 @@
+import { getCurrentUser } from "@/features/auth/utils/session";
+import { listingDAL, serviceListingDAL } from "@/dal";
+import { getPayoutReadiness } from "@/features/payments/lib/payout-readiness";
+import { PayoutReadinessBanner } from "./payout-readiness-banner";
+
+/**
+ * Server-side wrapper for {@link PayoutReadinessBanner}.
+ *
+ * Renders nothing unless the current user has at least one published listing
+ * AND their Stripe Connect onboarding status is not `verified`.
+ */
+export async function PayoutReadinessBannerServer() {
+  const user = await getCurrentUser();
+  if (!user) return null;
+
+  const readiness = getPayoutReadiness(user);
+  if (readiness.onboardingStatus === "verified") return null;
+
+  const [hasRentalListings, hasServiceListings] = await Promise.all([
+    listingDAL.hasPublishedListings(user.id),
+    serviceListingDAL.hasPublishedListings(user.id),
+  ]);
+
+  if (!hasRentalListings && !hasServiceListings) return null;
+
+  return (
+    <PayoutReadinessBanner onboardingStatus={readiness.onboardingStatus} />
+  );
+}

--- a/src/features/payments/components/payout-readiness-banner.tsx
+++ b/src/features/payments/components/payout-readiness-banner.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+import Link from "next/link";
+import { AlertCircle, X } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import type { OnboardingStatus } from "@/features/payments/lib/payout-readiness";
+
+const DISMISS_KEY = "payout-readiness-banner-dismissed";
+const CTA_HREF = "/dashboard/payments/earnings-and-payouts";
+
+type CopyVariant = Exclude<OnboardingStatus, "verified">;
+
+const COPY: Record<CopyVariant, { message: string; cta: string }> = {
+  not_started: {
+    message:
+      "Connect your payout account so you can accept bookings the moment a request comes in.",
+    cta: "Connect now",
+  },
+  pending: {
+    message: "Finish setting up your payout account to accept bookings.",
+    cta: "Finish setup",
+  },
+  restricted: {
+    message:
+      "Your payout account needs an update. Bookings can't be accepted until this is fixed.",
+    cta: "Update now",
+  },
+};
+
+const listeners = new Set<() => void>();
+
+function subscribe(callback: () => void) {
+  listeners.add(callback);
+  return () => {
+    listeners.delete(callback);
+  };
+}
+
+function getDismissedSnapshot(): boolean {
+  try {
+    return sessionStorage.getItem(DISMISS_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+// Treat the banner as dismissed during SSR — it will hydrate to the real
+// value after mount via useSyncExternalStore.
+function getDismissedServerSnapshot(): boolean {
+  return true;
+}
+
+function dismissBanner() {
+  try {
+    sessionStorage.setItem(DISMISS_KEY, "1");
+  } catch {
+    // best effort — sessionStorage can throw in privacy modes
+  }
+  for (const listener of listeners) listener();
+}
+
+export interface PayoutReadinessBannerProps {
+  onboardingStatus: CopyVariant;
+  className?: string;
+}
+
+export function PayoutReadinessBanner({
+  onboardingStatus,
+  className,
+}: PayoutReadinessBannerProps) {
+  const dismissed = useSyncExternalStore(
+    subscribe,
+    getDismissedSnapshot,
+    getDismissedServerSnapshot,
+  );
+
+  if (dismissed) return null;
+
+  const { message, cta } = COPY[onboardingStatus];
+
+  return (
+    <div
+      role="status"
+      className={cn(
+        "mb-4 flex items-start gap-3 rounded-lg border border-amber-200 bg-amber-50 p-4 dark:border-amber-900 dark:bg-amber-950/30",
+        className,
+      )}
+    >
+      <AlertCircle className="mt-0.5 h-5 w-5 shrink-0 text-amber-600 dark:text-amber-400" />
+      <div className="min-w-0 flex-1">
+        <p className="text-sm text-amber-900 dark:text-amber-100">{message}</p>
+        <div className="mt-3">
+          <Button asChild size="sm">
+            <Link href={CTA_HREF}>{cta}</Link>
+          </Button>
+        </div>
+      </div>
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon"
+        aria-label="Dismiss payout setup reminder"
+        onClick={dismissBanner}
+        className="-mt-1 -mr-1 h-7 w-7 text-amber-700 hover:bg-amber-100 hover:text-amber-900 dark:text-amber-300 dark:hover:bg-amber-900/50 dark:hover:text-amber-100"
+      >
+        <X className="h-4 w-4" />
+      </Button>
+    </div>
+  );
+}

--- a/src/features/payments/components/payout-setup-required-dialog.tsx
+++ b/src/features/payments/components/payout-setup-required-dialog.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { AlertCircle } from "lucide-react";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import type { OnboardingStatus } from "@/features/payments/lib/payout-readiness";
+
+type GatedStatus = Exclude<OnboardingStatus, "verified">;
+
+const COPY: Record<
+  GatedStatus,
+  { title: string; description: string; cta: string }
+> = {
+  not_started: {
+    title: "Connect your payout account",
+    description:
+      "Before you can accept this booking, connect a payout account so we can pay you when the renter is charged.",
+    cta: "Connect now",
+  },
+  pending: {
+    title: "Finish setting up your payout account",
+    description:
+      "Your payout setup isn't finished yet. Complete a few more details so we can pay you when this booking is charged.",
+    cta: "Finish setup",
+  },
+  restricted: {
+    title: "Your payout account needs an update",
+    description:
+      "Your payout account is missing information. Update it so this booking can be accepted and you can get paid.",
+    cta: "Update now",
+  },
+};
+
+export interface PayoutSetupRequiredDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onboardingStatus: GatedStatus;
+}
+
+export function PayoutSetupRequiredDialog({
+  open,
+  onOpenChange,
+  onboardingStatus,
+}: PayoutSetupRequiredDialogProps) {
+  const router = useRouter();
+  const { title, description, cta } = COPY[onboardingStatus];
+
+  const handleConnect = () => {
+    const returnTo = encodeURIComponent(
+      window.location.pathname + window.location.search,
+    );
+    router.push(
+      `/dashboard/payments/earnings-and-payouts?returnTo=${returnTo}`,
+    );
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[440px]">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <AlertCircle className="h-5 w-5 text-amber-600" />
+            {title}
+          </DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+          >
+            Not now
+          </Button>
+          <Button type="button" onClick={handleConnect}>
+            {cta}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/features/payments/lib/__tests__/assert-connect-ready.test.ts
+++ b/src/features/payments/lib/__tests__/assert-connect-ready.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const {
+  getUserByIdMock,
+  updateConnectOnboardingStatusMock,
+  getAccountStatusMock,
+  isRetryablePaymentErrorMock,
+  logGatingEventMock,
+} = vi.hoisted(() => ({
+  getUserByIdMock: vi.fn(),
+  updateConnectOnboardingStatusMock: vi.fn(),
+  getAccountStatusMock: vi.fn(),
+  isRetryablePaymentErrorMock: vi.fn(),
+  logGatingEventMock: vi.fn(),
+}));
+
+vi.mock("@/dal", () => ({
+  userDAL: {
+    getUserById: getUserByIdMock,
+    updateConnectOnboardingStatus: updateConnectOnboardingStatusMock,
+  },
+}));
+
+vi.mock("@/services/stripe/connect", () => ({
+  getAccountStatus: getAccountStatusMock,
+}));
+
+vi.mock("@/services/stripe/rental-payments", () => ({
+  isRetryablePaymentError: isRetryablePaymentErrorMock,
+}));
+
+vi.mock("../log-events", () => ({
+  logGatingEvent: logGatingEventMock,
+}));
+
+import { assertConnectReady } from "../assert-connect-ready";
+import { PaymentSetupRequiredError } from "../errors";
+
+const VERIFIED_USER = {
+  id: "user-1",
+  stripeConnectedAccountId: "acct_123",
+  connectChargesEnabled: true,
+  connectPayoutsEnabled: true,
+  connectOnboardingComplete: true,
+};
+
+const OPTS = { bookingType: "rental" as const, bookingId: "rental-99" };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("assertConnectReady", () => {
+  it("throws without calling Stripe when cached flags say not-verified (not_started)", async () => {
+    getUserByIdMock.mockResolvedValue({
+      ...VERIFIED_USER,
+      stripeConnectedAccountId: null,
+      connectChargesEnabled: false,
+      connectPayoutsEnabled: false,
+      connectOnboardingComplete: false,
+    });
+
+    await expect(assertConnectReady("user-1", OPTS)).rejects.toBeInstanceOf(
+      PaymentSetupRequiredError,
+    );
+    expect(getAccountStatusMock).not.toHaveBeenCalled();
+    expect(updateConnectOnboardingStatusMock).not.toHaveBeenCalled();
+    expect(logGatingEventMock).toHaveBeenCalledWith(
+      "accept_blocked_payment_setup_required",
+      expect.objectContaining({
+        userId: "user-1",
+        bookingType: "rental",
+        bookingId: "rental-99",
+        onboardingStatus: "not_started",
+      }),
+    );
+  });
+
+  it("throws without calling Stripe when cached flags say pending", async () => {
+    getUserByIdMock.mockResolvedValue({
+      ...VERIFIED_USER,
+      connectChargesEnabled: false,
+      connectPayoutsEnabled: false,
+      connectOnboardingComplete: false,
+    });
+
+    await expect(assertConnectReady("user-1", OPTS)).rejects.toMatchObject({
+      code: "PAYMENT_SETUP_REQUIRED",
+      details: expect.objectContaining({ onboardingStatus: "pending" }),
+    });
+    expect(getAccountStatusMock).not.toHaveBeenCalled();
+  });
+
+  it("throws without calling Stripe when cached flags say restricted", async () => {
+    getUserByIdMock.mockResolvedValue({
+      ...VERIFIED_USER,
+      connectChargesEnabled: true,
+      connectPayoutsEnabled: false,
+      connectOnboardingComplete: true,
+    });
+
+    await expect(assertConnectReady("user-1", OPTS)).rejects.toMatchObject({
+      code: "PAYMENT_SETUP_REQUIRED",
+      details: expect.objectContaining({
+        onboardingStatus: "restricted",
+        missingCapabilities: ["payouts"],
+      }),
+    });
+    expect(getAccountStatusMock).not.toHaveBeenCalled();
+  });
+
+  it("resolves when cached flags pass and live retrieve confirms both capabilities", async () => {
+    getUserByIdMock.mockResolvedValue(VERIFIED_USER);
+    getAccountStatusMock.mockResolvedValue({
+      chargesEnabled: true,
+      payoutsEnabled: true,
+    });
+
+    await expect(assertConnectReady("user-1", OPTS)).resolves.toBeUndefined();
+    expect(getAccountStatusMock).toHaveBeenCalledWith("acct_123");
+    expect(updateConnectOnboardingStatusMock).not.toHaveBeenCalled();
+    expect(logGatingEventMock).not.toHaveBeenCalled();
+  });
+
+  it("syncs DB and throws when live retrieve shows capability regression", async () => {
+    getUserByIdMock.mockResolvedValue(VERIFIED_USER);
+    getAccountStatusMock.mockResolvedValue({
+      chargesEnabled: true,
+      payoutsEnabled: false,
+    });
+
+    await expect(assertConnectReady("user-1", OPTS)).rejects.toMatchObject({
+      code: "PAYMENT_SETUP_REQUIRED",
+      details: expect.objectContaining({
+        onboardingStatus: "restricted",
+        missingCapabilities: ["payouts"],
+      }),
+    });
+    expect(updateConnectOnboardingStatusMock).toHaveBeenCalledWith("user-1", {
+      chargesEnabled: true,
+      payoutsEnabled: false,
+    });
+    expect(logGatingEventMock).toHaveBeenCalledWith(
+      "accept_blocked_payment_setup_required",
+      expect.objectContaining({
+        onboardingStatus: "restricted",
+        regression: true,
+      }),
+    );
+  });
+
+  it("retries once on transient Stripe error then succeeds", async () => {
+    getUserByIdMock.mockResolvedValue(VERIFIED_USER);
+    isRetryablePaymentErrorMock.mockReturnValue(true);
+    getAccountStatusMock
+      .mockRejectedValueOnce(new Error("rate-limited"))
+      .mockResolvedValueOnce({ chargesEnabled: true, payoutsEnabled: true });
+
+    const promise = assertConnectReady("user-1", OPTS);
+    await vi.advanceTimersByTimeAsync(1000);
+    await expect(promise).resolves.toBeUndefined();
+    expect(getAccountStatusMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("throws stripe_unreachable when transient error persists after retry", async () => {
+    getUserByIdMock.mockResolvedValue(VERIFIED_USER);
+    isRetryablePaymentErrorMock.mockReturnValue(true);
+    getAccountStatusMock
+      .mockRejectedValueOnce(new Error("rate-limited"))
+      .mockRejectedValueOnce(new Error("still rate-limited"));
+
+    const promise = assertConnectReady("user-1", OPTS);
+    await vi.advanceTimersByTimeAsync(1000);
+    await expect(promise).rejects.toMatchObject({
+      code: "PAYMENT_SETUP_REQUIRED",
+      details: {
+        onboardingStatus: "unknown",
+        reason: "stripe_unreachable",
+      },
+    });
+    expect(getAccountStatusMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("throws stripe_unreachable immediately on non-transient error (no retry)", async () => {
+    getUserByIdMock.mockResolvedValue(VERIFIED_USER);
+    isRetryablePaymentErrorMock.mockReturnValue(false);
+    getAccountStatusMock.mockRejectedValue(
+      new Error("invalid request — non-transient"),
+    );
+
+    await expect(assertConnectReady("user-1", OPTS)).rejects.toMatchObject({
+      code: "PAYMENT_SETUP_REQUIRED",
+      details: { onboardingStatus: "unknown", reason: "stripe_unreachable" },
+    });
+    expect(getAccountStatusMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("includes bookingType=service in the log when called from service flow", async () => {
+    getUserByIdMock.mockResolvedValue({
+      ...VERIFIED_USER,
+      stripeConnectedAccountId: null,
+    });
+
+    await expect(
+      assertConnectReady("user-1", {
+        bookingType: "service",
+        bookingId: "sb-1",
+      }),
+    ).rejects.toBeDefined();
+    expect(logGatingEventMock).toHaveBeenCalledWith(
+      "accept_blocked_payment_setup_required",
+      expect.objectContaining({ bookingType: "service", bookingId: "sb-1" }),
+    );
+  });
+});

--- a/src/features/payments/lib/__tests__/expire-pending-bookings.test.ts
+++ b/src/features/payments/lib/__tests__/expire-pending-bookings.test.ts
@@ -1,0 +1,278 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const {
+  findPendingExpiredRequestsMock,
+  markRequestExpiredMock,
+  findPendingExpiredServiceMock,
+  markServiceExpiredMock,
+  getUserByIdMock,
+  releaseDepositHoldMock,
+  sendNotificationMock,
+  logGatingEventMock,
+  loggerErrorMock,
+} = vi.hoisted(() => ({
+  findPendingExpiredRequestsMock: vi.fn(),
+  markRequestExpiredMock: vi.fn(),
+  findPendingExpiredServiceMock: vi.fn(),
+  markServiceExpiredMock: vi.fn(),
+  getUserByIdMock: vi.fn(),
+  releaseDepositHoldMock: vi.fn(),
+  sendNotificationMock: vi.fn(),
+  logGatingEventMock: vi.fn(),
+  loggerErrorMock: vi.fn(),
+}));
+
+vi.mock("@/dal", () => ({
+  rentalDAL: {
+    findPendingExpiredRequests: findPendingExpiredRequestsMock,
+    markRequestExpired: markRequestExpiredMock,
+  },
+  serviceBookingDAL: {
+    findPendingExpired: findPendingExpiredServiceMock,
+    markExpired: markServiceExpiredMock,
+  },
+  userDAL: {
+    getUserById: getUserByIdMock,
+  },
+}));
+
+vi.mock("@/services/stripe/deposit-hold", () => ({
+  releaseDepositHold: releaseDepositHoldMock,
+}));
+
+vi.mock("@/features/notifications/utils/send-notification", () => ({
+  sendNotification: sendNotificationMock,
+}));
+
+vi.mock("@/lib/logger", () => ({
+  getLogger: () => ({
+    error: loggerErrorMock,
+    info: vi.fn(),
+    warn: vi.fn(),
+  }),
+}));
+
+vi.mock("../log-events", () => ({
+  logGatingEvent: logGatingEventMock,
+}));
+
+import { expirePendingBookings } from "../expire-pending-bookings";
+
+const RENTAL_ROW = {
+  id: "rental-1",
+  renterId: "renter-1",
+  ownerId: "owner-1",
+  listingId: "listing-1",
+  listingName: "Power Washer",
+  securityDepositAuthId: "pi_dep_123",
+};
+
+const SERVICE_ROW = {
+  id: "svc-1",
+  requesterId: "requester-1",
+  providerId: "provider-1",
+  listingId: "svc-listing-1",
+  listingTitle: "Lawn Mowing",
+};
+
+const VERIFIED_USER = {
+  stripeConnectedAccountId: "acct_1",
+  connectChargesEnabled: true,
+  connectPayoutsEnabled: true,
+  connectOnboardingComplete: true,
+};
+
+const PENDING_USER = {
+  stripeConnectedAccountId: "acct_2",
+  connectChargesEnabled: false,
+  connectPayoutsEnabled: false,
+  connectOnboardingComplete: false,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  findPendingExpiredRequestsMock.mockResolvedValue([]);
+  findPendingExpiredServiceMock.mockResolvedValue([]);
+  markRequestExpiredMock.mockResolvedValue(true);
+  markServiceExpiredMock.mockResolvedValue(true);
+  getUserByIdMock.mockResolvedValue(VERIFIED_USER);
+  releaseDepositHoldMock.mockResolvedValue(undefined);
+  sendNotificationMock.mockResolvedValue({ success: true });
+});
+
+describe("expirePendingBookings", () => {
+  it("returns zero counts when no rows are eligible", async () => {
+    const result = await expirePendingBookings();
+
+    expect(result).toEqual({
+      rentalsChecked: 0,
+      servicesChecked: 0,
+      expiredCount: 0,
+      failedCount: 0,
+    });
+    expect(markRequestExpiredMock).not.toHaveBeenCalled();
+    expect(sendNotificationMock).not.toHaveBeenCalled();
+  });
+
+  it("expires a pending rental: marks cancelled, releases hold, notifies both parties", async () => {
+    findPendingExpiredRequestsMock.mockResolvedValue([RENTAL_ROW]);
+    getUserByIdMock.mockResolvedValue(VERIFIED_USER);
+
+    const result = await expirePendingBookings();
+
+    expect(result.expiredCount).toBe(1);
+    expect(result.failedCount).toBe(0);
+    expect(markRequestExpiredMock).toHaveBeenCalledWith("rental-1");
+    expect(releaseDepositHoldMock).toHaveBeenCalledWith("pi_dep_123");
+    expect(sendNotificationMock).toHaveBeenCalledTimes(2);
+
+    const calls = sendNotificationMock.mock.calls.map((c) => c[0]);
+    const renterCall = calls.find((c) => c.userId === "renter-1");
+    expect(renterCall).toMatchObject({
+      type: "rental_cancelled",
+      title: "Rental request expired",
+    });
+    expect(renterCall?.message).toContain("Power Washer");
+    expect(renterCall?.message).toContain("did not respond in time");
+    expect(renterCall?.message).not.toMatch(/Stripe|payout|connect/i);
+
+    const ownerCall = calls.find((c) => c.userId === "owner-1");
+    expect(ownerCall?.message).not.toMatch(/Set up your payout account/);
+    expect(ownerCall?.linkUrl).toBe("/dashboard/rental/rental-1");
+
+    expect(logGatingEventMock).not.toHaveBeenCalled();
+  });
+
+  it("includes a soft payout prompt and logs the gating event when the owner is not payout-ready", async () => {
+    findPendingExpiredRequestsMock.mockResolvedValue([RENTAL_ROW]);
+    getUserByIdMock.mockResolvedValue(PENDING_USER);
+
+    await expirePendingBookings();
+
+    const ownerCall = sendNotificationMock.mock.calls
+      .map((c) => c[0])
+      .find((c) => c.userId === "owner-1");
+    expect(ownerCall?.message).toContain("Set up your payout account");
+    expect(ownerCall?.linkUrl).toBe("/dashboard/payments/earnings-and-payouts");
+
+    expect(logGatingEventMock).toHaveBeenCalledWith(
+      "pending_booking_expired_owner_not_ready",
+      expect.objectContaining({
+        userId: "owner-1",
+        bookingType: "rental",
+        bookingId: "rental-1",
+        onboardingStatus: "pending",
+      }),
+    );
+
+    const renterCall = sendNotificationMock.mock.calls
+      .map((c) => c[0])
+      .find((c) => c.userId === "renter-1");
+    expect(renterCall?.message).not.toMatch(/Stripe|payout|connect/i);
+  });
+
+  it("skips deposit release for a rental with no securityDepositAuthId", async () => {
+    findPendingExpiredRequestsMock.mockResolvedValue([
+      { ...RENTAL_ROW, securityDepositAuthId: null },
+    ]);
+
+    await expirePendingBookings();
+
+    expect(releaseDepositHoldMock).not.toHaveBeenCalled();
+    expect(sendNotificationMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("counts the row as expired but logs an error when deposit release fails", async () => {
+    findPendingExpiredRequestsMock.mockResolvedValue([RENTAL_ROW]);
+    releaseDepositHoldMock.mockRejectedValueOnce(new Error("stripe boom"));
+
+    const result = await expirePendingBookings();
+
+    expect(result.expiredCount).toBe(1);
+    expect(result.failedCount).toBe(0);
+    expect(loggerErrorMock).toHaveBeenCalled();
+    expect(sendNotificationMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not double-expire: when markRequestExpired returns false the row is skipped", async () => {
+    findPendingExpiredRequestsMock.mockResolvedValue([RENTAL_ROW]);
+    markRequestExpiredMock.mockResolvedValueOnce(false);
+
+    const result = await expirePendingBookings();
+
+    expect(result.expiredCount).toBe(0);
+    expect(releaseDepositHoldMock).not.toHaveBeenCalled();
+    expect(sendNotificationMock).not.toHaveBeenCalled();
+  });
+
+  it("isolates per-row failures so one bad row does not stop the batch", async () => {
+    findPendingExpiredRequestsMock.mockResolvedValue([
+      { ...RENTAL_ROW, id: "rental-a" },
+      { ...RENTAL_ROW, id: "rental-b" },
+    ]);
+    markRequestExpiredMock.mockImplementation(async (id: string) => {
+      if (id === "rental-a") throw new Error("db fail");
+      return true;
+    });
+
+    const result = await expirePendingBookings();
+
+    expect(result.rentalsChecked).toBe(2);
+    expect(result.expiredCount).toBe(1);
+    expect(result.failedCount).toBe(1);
+    expect(loggerErrorMock).toHaveBeenCalled();
+  });
+
+  it("expires service bookings: notifies both parties, no deposit release", async () => {
+    findPendingExpiredServiceMock.mockResolvedValue([SERVICE_ROW]);
+    getUserByIdMock.mockResolvedValue(VERIFIED_USER);
+
+    const result = await expirePendingBookings();
+
+    expect(result.expiredCount).toBe(1);
+    expect(markServiceExpiredMock).toHaveBeenCalledWith("svc-1");
+    expect(releaseDepositHoldMock).not.toHaveBeenCalled();
+    expect(sendNotificationMock).toHaveBeenCalledTimes(2);
+
+    const renterCall = sendNotificationMock.mock.calls
+      .map((c) => c[0])
+      .find((c) => c.userId === "requester-1");
+    expect(renterCall).toMatchObject({
+      type: "service_booking_declined",
+    });
+    expect(renterCall?.message).toContain("Lawn Mowing");
+    expect(renterCall?.message).not.toMatch(/Stripe|payout|connect/i);
+  });
+
+  it("logs soft-prompt gating event for service bookings when provider is not payout-ready", async () => {
+    findPendingExpiredServiceMock.mockResolvedValue([SERVICE_ROW]);
+    getUserByIdMock.mockResolvedValue(PENDING_USER);
+
+    await expirePendingBookings();
+
+    expect(logGatingEventMock).toHaveBeenCalledWith(
+      "pending_booking_expired_owner_not_ready",
+      expect.objectContaining({
+        userId: "provider-1",
+        bookingType: "service",
+        bookingId: "svc-1",
+        onboardingStatus: "pending",
+      }),
+    );
+
+    const providerCall = sendNotificationMock.mock.calls
+      .map((c) => c[0])
+      .find((c) => c.userId === "provider-1");
+    expect(providerCall?.message).toContain("Set up your payout account");
+    expect(providerCall?.linkUrl).toBe(
+      "/dashboard/payments/earnings-and-payouts",
+    );
+  });
+
+  it("uses the provided `now` to drive both DAL queries", async () => {
+    const now = new Date("2026-05-18T10:00:00Z");
+    await expirePendingBookings(now);
+    expect(findPendingExpiredRequestsMock).toHaveBeenCalledWith(now);
+    expect(findPendingExpiredServiceMock).toHaveBeenCalledWith(now);
+  });
+});

--- a/src/features/payments/lib/__tests__/log-events.test.ts
+++ b/src/features/payments/lib/__tests__/log-events.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const infoMock = vi.fn();
+
+vi.mock("@/lib/logger", () => ({
+  getLogger: () => ({
+    info: infoMock,
+  }),
+}));
+
+import { logGatingEvent } from "../log-events";
+
+describe("logGatingEvent", () => {
+  beforeEach(() => {
+    infoMock.mockClear();
+  });
+
+  it("emits an info log with the event name as both a field and the message", () => {
+    logGatingEvent("listing_created_without_stripe_connect", {
+      userId: "user-1",
+      listingId: "listing-99",
+      onboardingStatus: "not_started",
+    });
+
+    expect(infoMock).toHaveBeenCalledTimes(1);
+    const [merge, msg] = infoMock.mock.calls[0]!;
+    expect(merge).toEqual({
+      event: "listing_created_without_stripe_connect",
+      userId: "user-1",
+      listingId: "listing-99",
+      onboardingStatus: "not_started",
+    });
+    expect(msg).toBe("listing_created_without_stripe_connect");
+  });
+
+  it("includes bookingType and bookingId when provided", () => {
+    logGatingEvent("accept_blocked_payment_setup_required", {
+      userId: "user-2",
+      bookingType: "rental",
+      bookingId: "rental-42",
+      onboardingStatus: "restricted",
+    });
+
+    const [merge] = infoMock.mock.calls[0]!;
+    expect(merge).toMatchObject({
+      event: "accept_blocked_payment_setup_required",
+      bookingType: "rental",
+      bookingId: "rental-42",
+      onboardingStatus: "restricted",
+    });
+  });
+
+  it("allows arbitrary extra properties", () => {
+    logGatingEvent("accept_blocked_payment_setup_required", {
+      userId: "user-3",
+      regression: true,
+      reason: "stripe_unreachable",
+    });
+
+    const [merge] = infoMock.mock.calls[0]!;
+    expect(merge).toMatchObject({
+      regression: true,
+      reason: "stripe_unreachable",
+    });
+  });
+});

--- a/src/features/payments/lib/__tests__/payout-readiness.test.ts
+++ b/src/features/payments/lib/__tests__/payout-readiness.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from "vitest";
+import {
+  getPayoutReadiness,
+  type PayoutReadinessUserFields,
+} from "../payout-readiness";
+
+function userFields(
+  overrides: Partial<PayoutReadinessUserFields> = {},
+): PayoutReadinessUserFields {
+  return {
+    stripeConnectedAccountId: null,
+    connectChargesEnabled: false,
+    connectPayoutsEnabled: false,
+    connectOnboardingComplete: false,
+    ...overrides,
+  };
+}
+
+describe("getPayoutReadiness", () => {
+  it("returns not_started when stripeConnectedAccountId is null", () => {
+    const result = getPayoutReadiness(userFields());
+
+    expect(result).toEqual({
+      stripeConnected: false,
+      chargesEnabled: false,
+      payoutsEnabled: false,
+      onboardingStatus: "not_started",
+    });
+  });
+
+  it("returns not_started even when capability flags are set but no account id", () => {
+    const result = getPayoutReadiness(
+      userFields({
+        connectChargesEnabled: true,
+        connectPayoutsEnabled: true,
+        connectOnboardingComplete: true,
+      }),
+    );
+
+    expect(result.onboardingStatus).toBe("not_started");
+    expect(result.stripeConnected).toBe(false);
+  });
+
+  it("returns pending when account exists but onboarding is not complete and both flags are false", () => {
+    const result = getPayoutReadiness(
+      userFields({
+        stripeConnectedAccountId: "acct_123",
+        connectOnboardingComplete: false,
+      }),
+    );
+
+    expect(result).toEqual({
+      stripeConnected: true,
+      chargesEnabled: false,
+      payoutsEnabled: false,
+      onboardingStatus: "pending",
+    });
+  });
+
+  it("returns verified when both capability flags are true", () => {
+    const result = getPayoutReadiness(
+      userFields({
+        stripeConnectedAccountId: "acct_123",
+        connectChargesEnabled: true,
+        connectPayoutsEnabled: true,
+        connectOnboardingComplete: true,
+      }),
+    );
+
+    expect(result).toEqual({
+      stripeConnected: true,
+      chargesEnabled: true,
+      payoutsEnabled: true,
+      onboardingStatus: "verified",
+    });
+  });
+
+  it("returns verified when both flags are true even if connectOnboardingComplete is false", () => {
+    // Live state from Stripe is the source of truth — if both capabilities are
+    // enabled, the user is verified regardless of the stale onboarding flag.
+    const result = getPayoutReadiness(
+      userFields({
+        stripeConnectedAccountId: "acct_123",
+        connectChargesEnabled: true,
+        connectPayoutsEnabled: true,
+        connectOnboardingComplete: false,
+      }),
+    );
+
+    expect(result.onboardingStatus).toBe("verified");
+  });
+
+  it("returns restricted when charges_enabled is true but payouts_enabled is false and onboarding is marked complete", () => {
+    const result = getPayoutReadiness(
+      userFields({
+        stripeConnectedAccountId: "acct_123",
+        connectChargesEnabled: true,
+        connectPayoutsEnabled: false,
+        connectOnboardingComplete: true,
+      }),
+    );
+
+    expect(result).toEqual({
+      stripeConnected: true,
+      chargesEnabled: true,
+      payoutsEnabled: false,
+      onboardingStatus: "restricted",
+    });
+  });
+
+  it("returns restricted when payouts_enabled is true but charges_enabled is false and onboarding is marked complete", () => {
+    const result = getPayoutReadiness(
+      userFields({
+        stripeConnectedAccountId: "acct_123",
+        connectChargesEnabled: false,
+        connectPayoutsEnabled: true,
+        connectOnboardingComplete: true,
+      }),
+    );
+
+    expect(result.onboardingStatus).toBe("restricted");
+  });
+
+  it("returns pending when account exists, onboarding is incomplete, and one flag is enabled", () => {
+    // Partial capability before onboarding completes is treated as pending,
+    // not restricted — the user is still working through onboarding.
+    const result = getPayoutReadiness(
+      userFields({
+        stripeConnectedAccountId: "acct_123",
+        connectChargesEnabled: true,
+        connectPayoutsEnabled: false,
+        connectOnboardingComplete: false,
+      }),
+    );
+
+    expect(result.onboardingStatus).toBe("pending");
+  });
+});

--- a/src/features/payments/lib/__tests__/return-to.test.ts
+++ b/src/features/payments/lib/__tests__/return-to.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "vitest";
+import { validateReturnTo } from "../return-to";
+
+describe("validateReturnTo", () => {
+  describe("rejects unsafe input", () => {
+    it("rejects null", () => {
+      expect(validateReturnTo(null)).toBeNull();
+    });
+
+    it("rejects undefined", () => {
+      expect(validateReturnTo(undefined)).toBeNull();
+    });
+
+    it("rejects non-string values", () => {
+      expect(validateReturnTo(123)).toBeNull();
+      expect(validateReturnTo({})).toBeNull();
+      expect(validateReturnTo([])).toBeNull();
+    });
+
+    it("rejects empty string", () => {
+      expect(validateReturnTo("")).toBeNull();
+    });
+
+    it("rejects absolute URLs", () => {
+      expect(validateReturnTo("https://evil.com")).toBeNull();
+      expect(
+        validateReturnTo("http://evil.com/dashboard/rentals/1"),
+      ).toBeNull();
+    });
+
+    it("rejects protocol-relative URLs that could spoof another host", () => {
+      expect(validateReturnTo("//evil.com")).toBeNull();
+      expect(validateReturnTo("//evil.com/dashboard/rentals/1")).toBeNull();
+    });
+
+    it("rejects relative paths outside /dashboard/", () => {
+      expect(validateReturnTo("/login")).toBeNull();
+      expect(validateReturnTo("/admin")).toBeNull();
+      expect(validateReturnTo("/api/internal/secret")).toBeNull();
+    });
+
+    it("rejects bare /dashboard with no trailing path", () => {
+      expect(validateReturnTo("/dashboard")).toBeNull();
+      // /dashboard/ followed by nothing should also reject — we want a real path.
+      expect(validateReturnTo("/dashboard/")).toBeNull();
+    });
+  });
+
+  describe("accepts safe dashboard paths", () => {
+    it("accepts /dashboard/rentals/[id]", () => {
+      expect(validateReturnTo("/dashboard/rentals/abc-123")).toBe(
+        "/dashboard/rentals/abc-123",
+      );
+    });
+
+    it("accepts /dashboard/(rentals)/rental/[id]", () => {
+      const url = "/dashboard/rental/req-456";
+      expect(validateReturnTo(url)).toBe(url);
+    });
+
+    it("accepts paths with query strings", () => {
+      const url = "/dashboard/rentals/abc?view=detail";
+      expect(validateReturnTo(url)).toBe(url);
+    });
+
+    it("accepts deeper paths under /dashboard/", () => {
+      expect(validateReturnTo("/dashboard/services/bookings/x-1")).toBe(
+        "/dashboard/services/bookings/x-1",
+      );
+    });
+  });
+});

--- a/src/features/payments/lib/assert-connect-ready.ts
+++ b/src/features/payments/lib/assert-connect-ready.ts
@@ -1,0 +1,143 @@
+import { userDAL } from "@/dal";
+import { getAccountStatus } from "@/services/stripe/connect";
+import { isRetryablePaymentError } from "@/services/stripe/rental-payments";
+import { PaymentSetupRequiredError } from "./errors";
+import { logGatingEvent } from "./log-events";
+import { getPayoutReadiness, type OnboardingStatus } from "./payout-readiness";
+
+export type AssertConnectReadyOptions = {
+  bookingType: "rental" | "service";
+  bookingId: string;
+};
+
+/**
+ * Asserts that the given user is ready to receive payouts at the moment of
+ * accepting a booking. Two-layer check:
+ *
+ * 1. Fast path — cached `connectChargesEnabled` / `connectPayoutsEnabled` columns.
+ *    If not both true, throw immediately without calling Stripe.
+ * 2. Authoritative path — live `stripe.accounts.retrieve()` to catch capability
+ *    regressions and webhook lag. One retry on transient Stripe errors. If the
+ *    live response shows regression, cached flags are updated to match before
+ *    throwing.
+ *
+ * On Stripe being unreachable after retry, fail closed (throw with
+ * `reason: 'stripe_unreachable'`) rather than allow the accept to proceed.
+ */
+export async function assertConnectReady(
+  userId: string,
+  opts: AssertConnectReadyOptions,
+): Promise<void> {
+  const user = await userDAL.getUserById(userId);
+  const readiness = getPayoutReadiness({
+    stripeConnectedAccountId: user.stripeConnectedAccountId ?? null,
+    connectChargesEnabled: user.connectChargesEnabled,
+    connectPayoutsEnabled: user.connectPayoutsEnabled,
+    connectOnboardingComplete: user.connectOnboardingComplete,
+  });
+
+  if (readiness.onboardingStatus !== "verified") {
+    throwPaymentSetupRequired(userId, opts, readiness.onboardingStatus, {
+      missingCapabilities: missingCapabilitiesFor(readiness),
+    });
+  }
+
+  // Cached flags say verified — confirm live before allowing money to move.
+  const accountId = user.stripeConnectedAccountId!;
+  const live = await retrieveAccountStatusWithRetry(accountId);
+
+  if (live === "unreachable") {
+    throwPaymentSetupRequired(userId, opts, "unknown", {
+      reason: "stripe_unreachable",
+    });
+  }
+
+  if (live.chargesEnabled && live.payoutsEnabled) {
+    return;
+  }
+
+  // Capability regression — sync cached flags before throwing so the next
+  // request short-circuits on the fast path.
+  await userDAL.updateConnectOnboardingStatus(userId, {
+    chargesEnabled: live.chargesEnabled,
+    payoutsEnabled: live.payoutsEnabled,
+  });
+
+  // Regression case: the user previously had both capabilities, so we surface
+  // this as `restricted` (post-onboarding capability loss) rather than `pending`
+  // (still in onboarding). We mark connectOnboardingComplete true to get that
+  // classification from getPayoutReadiness.
+  const liveReadiness = getPayoutReadiness({
+    stripeConnectedAccountId: accountId,
+    connectChargesEnabled: live.chargesEnabled,
+    connectPayoutsEnabled: live.payoutsEnabled,
+    connectOnboardingComplete: true,
+  });
+
+  throwPaymentSetupRequired(userId, opts, liveReadiness.onboardingStatus, {
+    missingCapabilities: missingCapabilitiesFor(liveReadiness),
+    regression: true,
+  });
+}
+
+type AccountStatus = Awaited<ReturnType<typeof getAccountStatus>>;
+
+async function retrieveAccountStatusWithRetry(
+  accountId: string,
+): Promise<AccountStatus | "unreachable"> {
+  try {
+    return await getAccountStatus(accountId);
+  } catch (error) {
+    if (!isRetryablePaymentError(error)) {
+      return "unreachable";
+    }
+    await sleep(1000);
+    try {
+      return await getAccountStatus(accountId);
+    } catch {
+      return "unreachable";
+    }
+  }
+}
+
+function missingCapabilitiesFor(readiness: {
+  chargesEnabled: boolean;
+  payoutsEnabled: boolean;
+}): ("charges" | "payouts")[] {
+  const missing: ("charges" | "payouts")[] = [];
+  if (!readiness.chargesEnabled) missing.push("charges");
+  if (!readiness.payoutsEnabled) missing.push("payouts");
+  return missing;
+}
+
+function throwPaymentSetupRequired(
+  userId: string,
+  opts: AssertConnectReadyOptions,
+  onboardingStatus: OnboardingStatus | "unknown",
+  extra: {
+    missingCapabilities?: ("charges" | "payouts")[];
+    reason?: "stripe_unreachable";
+    regression?: boolean;
+  } = {},
+): never {
+  logGatingEvent("accept_blocked_payment_setup_required", {
+    userId,
+    bookingType: opts.bookingType,
+    bookingId: opts.bookingId,
+    onboardingStatus,
+    ...(extra.regression ? { regression: true } : {}),
+    ...(extra.reason ? { reason: extra.reason } : {}),
+  });
+
+  throw new PaymentSetupRequiredError({
+    onboardingStatus,
+    ...(extra.missingCapabilities && extra.missingCapabilities.length > 0
+      ? { missingCapabilities: extra.missingCapabilities }
+      : {}),
+    ...(extra.reason ? { reason: extra.reason } : {}),
+  });
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/src/features/payments/lib/errors.ts
+++ b/src/features/payments/lib/errors.ts
@@ -1,0 +1,22 @@
+import type { OnboardingStatus } from "./payout-readiness";
+
+export type PaymentSetupRequiredDetails = {
+  onboardingStatus: OnboardingStatus | "unknown";
+  missingCapabilities?: ("charges" | "payouts")[];
+  reason?: "stripe_unreachable";
+};
+
+/**
+ * Thrown when an owner/provider attempts to accept a booking but their Stripe
+ * Connect account is not ready to receive payouts. API routes translate this
+ * to HTTP 403 with body { error: "PAYMENT_SETUP_REQUIRED", onboardingStatus, missingCapabilities }.
+ */
+export class PaymentSetupRequiredError extends Error {
+  public readonly code = "PAYMENT_SETUP_REQUIRED";
+  public readonly statusCode = 403;
+
+  constructor(public readonly details: PaymentSetupRequiredDetails) {
+    super("Payment setup required");
+    this.name = "PaymentSetupRequiredError";
+  }
+}

--- a/src/features/payments/lib/expire-pending-bookings.ts
+++ b/src/features/payments/lib/expire-pending-bookings.ts
@@ -1,0 +1,177 @@
+import { rentalDAL, serviceBookingDAL, userDAL } from "@/dal";
+import { releaseDepositHold } from "@/services/stripe/deposit-hold";
+import { sendNotification } from "@/features/notifications/utils/send-notification";
+import { getLogger } from "@/lib/logger";
+import { getPayoutReadiness } from "./payout-readiness";
+import { logGatingEvent } from "./log-events";
+
+export interface ExpirePendingBookingsResult {
+  rentalsChecked: number;
+  servicesChecked: number;
+  expiredCount: number;
+  failedCount: number;
+}
+
+/**
+ * Auto-cancel pending rental requests and service bookings whose `expiresAt`
+ * has passed. Triggered hourly by /api/cron/expire-pending-bookings.
+ *
+ * Per-row try/catch — one failing row does not stop the batch.
+ */
+export async function expirePendingBookings(
+  now: Date = new Date(),
+): Promise<ExpirePendingBookingsResult> {
+  const [pendingRentals, pendingServices] = await Promise.all([
+    rentalDAL.findPendingExpiredRequests(now),
+    serviceBookingDAL.findPendingExpired(now),
+  ]);
+
+  let expiredCount = 0;
+  let failedCount = 0;
+
+  for (const row of pendingRentals) {
+    try {
+      const updated = await rentalDAL.markRequestExpired(row.id);
+      if (!updated) continue;
+      expiredCount++;
+      await processExpiredRental(row);
+    } catch (error) {
+      failedCount++;
+      getLogger().error(
+        { err: error, bookingType: "rental", bookingId: row.id },
+        "expire-pending-bookings: rental row failed",
+      );
+    }
+  }
+
+  for (const row of pendingServices) {
+    try {
+      const updated = await serviceBookingDAL.markExpired(row.id);
+      if (!updated) continue;
+      expiredCount++;
+      await processExpiredService(row);
+    } catch (error) {
+      failedCount++;
+      getLogger().error(
+        { err: error, bookingType: "service", bookingId: row.id },
+        "expire-pending-bookings: service row failed",
+      );
+    }
+  }
+
+  return {
+    rentalsChecked: pendingRentals.length,
+    servicesChecked: pendingServices.length,
+    expiredCount,
+    failedCount,
+  };
+}
+
+async function processExpiredRental(row: {
+  id: string;
+  renterId: string;
+  ownerId: string;
+  listingId: string;
+  listingName: string;
+  securityDepositAuthId: string | null;
+}): Promise<void> {
+  if (row.securityDepositAuthId) {
+    try {
+      await releaseDepositHold(row.securityDepositAuthId);
+    } catch (error) {
+      getLogger().error(
+        {
+          err: error,
+          bookingType: "rental",
+          bookingId: row.id,
+          paymentIntentId: row.securityDepositAuthId,
+        },
+        "expire-pending-bookings: deposit hold release failed",
+      );
+    }
+  }
+
+  const owner = await userDAL.getUserById(row.ownerId);
+  const ownerStatus = owner
+    ? getPayoutReadiness(owner).onboardingStatus
+    : "unknown";
+
+  await sendNotification({
+    userId: row.renterId,
+    type: "rental_cancelled",
+    title: "Rental request expired",
+    message: `Your request for ${row.listingName} was cancelled because the owner did not respond in time.`,
+    data: { rentalRequestId: row.id, listingId: row.listingId },
+    linkUrl: `/dashboard/rental/${row.id}`,
+  });
+
+  const ownerNotPayoutReady = ownerStatus !== "verified";
+  await sendNotification({
+    userId: row.ownerId,
+    type: "rental_cancelled",
+    title: "Pending request expired",
+    message: ownerNotPayoutReady
+      ? `Your pending request for ${row.listingName} expired. Set up your payout account so you can accept future bookings the moment they come in.`
+      : `Your pending request for ${row.listingName} expired without acceptance.`,
+    data: { rentalRequestId: row.id, listingId: row.listingId },
+    linkUrl: ownerNotPayoutReady
+      ? `/dashboard/payments/earnings-and-payouts`
+      : `/dashboard/rental/${row.id}`,
+  });
+
+  if (ownerNotPayoutReady) {
+    logGatingEvent("pending_booking_expired_owner_not_ready", {
+      userId: row.ownerId,
+      bookingType: "rental",
+      bookingId: row.id,
+      listingId: row.listingId,
+      onboardingStatus: ownerStatus,
+    });
+  }
+}
+
+async function processExpiredService(row: {
+  id: string;
+  requesterId: string;
+  providerId: string;
+  listingId: string;
+  listingTitle: string;
+}): Promise<void> {
+  const provider = await userDAL.getUserById(row.providerId);
+  const providerStatus = provider
+    ? getPayoutReadiness(provider).onboardingStatus
+    : "unknown";
+
+  await sendNotification({
+    userId: row.requesterId,
+    type: "service_booking_declined",
+    title: "Booking request expired",
+    message: `Your booking request for "${row.listingTitle}" was cancelled because the provider did not respond in time.`,
+    data: { bookingId: row.id, listingId: row.listingId },
+    linkUrl: `/dashboard/services/bookings/${row.id}`,
+  });
+
+  const providerNotPayoutReady = providerStatus !== "verified";
+  await sendNotification({
+    userId: row.providerId,
+    type: "service_booking_declined",
+    title: "Pending booking expired",
+    message: providerNotPayoutReady
+      ? `Your pending booking for "${row.listingTitle}" expired. Set up your payout account so you can accept future bookings the moment they come in.`
+      : `Your pending booking for "${row.listingTitle}" expired without acceptance.`,
+    data: { bookingId: row.id, listingId: row.listingId },
+    linkUrl: providerNotPayoutReady
+      ? `/dashboard/payments/earnings-and-payouts`
+      : `/dashboard/services/bookings/${row.id}`,
+  });
+
+  if (providerNotPayoutReady) {
+    logGatingEvent("pending_booking_expired_owner_not_ready", {
+      userId: row.providerId,
+      bookingType: "service",
+      bookingId: row.id,
+      listingId: row.listingId,
+      onboardingStatus: providerStatus,
+    });
+  }
+}

--- a/src/features/payments/lib/log-events.ts
+++ b/src/features/payments/lib/log-events.ts
@@ -1,0 +1,25 @@
+import { getLogger } from "@/lib/logger";
+import type { OnboardingStatus } from "./payout-readiness";
+
+export type GatingEvent =
+  | "listing_created_without_stripe_connect"
+  | "connect_onboarding_started_from_accept"
+  | "connect_onboarding_completed_from_accept"
+  | "accept_blocked_payment_setup_required"
+  | "pending_booking_expired_owner_not_ready";
+
+export type GatingEventProps = {
+  userId: string;
+  bookingType?: "rental" | "service";
+  bookingId?: string;
+  listingId?: string;
+  onboardingStatus?: OnboardingStatus | "unknown";
+  [key: string]: unknown;
+};
+
+export function logGatingEvent(
+  event: GatingEvent,
+  props: GatingEventProps,
+): void {
+  getLogger().info({ event, ...props }, event);
+}

--- a/src/features/payments/lib/payout-readiness.ts
+++ b/src/features/payments/lib/payout-readiness.ts
@@ -1,0 +1,45 @@
+export type OnboardingStatus =
+  | "not_started"
+  | "pending"
+  | "restricted"
+  | "verified";
+
+export type PayoutReadiness = {
+  stripeConnected: boolean;
+  chargesEnabled: boolean;
+  payoutsEnabled: boolean;
+  onboardingStatus: OnboardingStatus;
+};
+
+export type PayoutReadinessUserFields = {
+  stripeConnectedAccountId: string | null;
+  connectChargesEnabled: boolean;
+  connectPayoutsEnabled: boolean;
+  connectOnboardingComplete: boolean;
+};
+
+export function getPayoutReadiness(
+  user: PayoutReadinessUserFields,
+): PayoutReadiness {
+  const stripeConnected = user.stripeConnectedAccountId !== null;
+  const chargesEnabled = user.connectChargesEnabled;
+  const payoutsEnabled = user.connectPayoutsEnabled;
+
+  let onboardingStatus: OnboardingStatus;
+  if (!stripeConnected) {
+    onboardingStatus = "not_started";
+  } else if (chargesEnabled && payoutsEnabled) {
+    onboardingStatus = "verified";
+  } else if (!user.connectOnboardingComplete) {
+    onboardingStatus = "pending";
+  } else {
+    onboardingStatus = "restricted";
+  }
+
+  return {
+    stripeConnected,
+    chargesEnabled,
+    payoutsEnabled,
+    onboardingStatus,
+  };
+}

--- a/src/features/payments/lib/return-to.ts
+++ b/src/features/payments/lib/return-to.ts
@@ -1,0 +1,21 @@
+/**
+ * Open-redirect protection for the JIT onboarding flow's `?returnTo=` param.
+ *
+ * Accepts only relative URLs that resolve under `/dashboard/`. Anything else
+ * (absolute URLs, protocol-relative `//evil.com`, paths outside `/dashboard/`,
+ * etc.) returns null and the caller falls back to default behavior.
+ */
+const DASHBOARD_PATH_PATTERN = /^\/dashboard\/[^/].*$/;
+
+export function validateReturnTo(input: unknown): string | null {
+  if (typeof input !== "string" || input.length === 0) {
+    return null;
+  }
+  // Reject protocol-relative URLs like "//evil.com" — the second char must not
+  // be a slash. The regex also covers this, but checking explicitly keeps the
+  // intent obvious.
+  if (input.startsWith("//")) {
+    return null;
+  }
+  return DASHBOARD_PATH_PATTERN.test(input) ? input : null;
+}

--- a/src/features/rentals/components/detail-page/rental-actions.tsx
+++ b/src/features/rentals/components/detail-page/rental-actions.tsx
@@ -29,6 +29,8 @@ import {
 import { FileDisputeDialog } from "@/features/disputes/components/file-dispute-dialog";
 import { TimeWindowValidation } from "@/features/disputes/lib/time-window-validation";
 import { ReviewFormDialog } from "@/features/reviews/components/review-form-dialog";
+import { PayoutSetupRequiredDialog } from "@/features/payments/components/payout-setup-required-dialog";
+import type { OnboardingStatus } from "@/features/payments/lib/payout-readiness";
 
 interface RentalActionsProps {
   rentalDetails: RentalActionsInfo;
@@ -39,6 +41,7 @@ interface RentalActionsProps {
   disputePolicyUrl?: string;
   activeDispute?: DisputeWithRelations | null;
   canReview?: boolean;
+  ownerOnboardingStatus?: OnboardingStatus;
 }
 
 export function RentalActions({
@@ -49,6 +52,7 @@ export function RentalActions({
   disputePolicyUrl,
   activeDispute,
   canReview: canReviewProp,
+  ownerOnboardingStatus,
 }: RentalActionsProps) {
   const router = useRouter();
   const [showCancelDialog, setShowCancelDialog] = useState(false);
@@ -58,6 +62,7 @@ export function RentalActions({
     "renter" | "owner"
   >("renter");
   const [showApproveDialog, setShowApproveDialog] = useState(false);
+  const [showPayoutSetupDialog, setShowPayoutSetupDialog] = useState(false);
   const [showDeclineDialog, setShowDeclineDialog] = useState(false);
   const [showUpdateInstructionsDialog, setShowUpdateInstructionsDialog] =
     useState(false);
@@ -161,7 +166,16 @@ export function RentalActions({
               <>
                 <Button
                   className="w-full"
-                  onClick={() => setShowApproveDialog(true)}
+                  onClick={() => {
+                    if (
+                      ownerOnboardingStatus &&
+                      ownerOnboardingStatus !== "verified"
+                    ) {
+                      setShowPayoutSetupDialog(true);
+                    } else {
+                      setShowApproveDialog(true);
+                    }
+                  }}
                 >
                   <CheckCircle className="mr-2 h-4 w-4" />
                   Approve
@@ -286,6 +300,16 @@ export function RentalActions({
         renterName={rentalDetails.renterName}
         deliveryRequested={rentalDetails.deliveryRequested}
       />
+
+      {/* Payout Setup Required Dialog — shown when Approve is clicked but the
+          owner's Stripe Connect onboarding is not yet verified. */}
+      {ownerOnboardingStatus && ownerOnboardingStatus !== "verified" && (
+        <PayoutSetupRequiredDialog
+          open={showPayoutSetupDialog}
+          onOpenChange={setShowPayoutSetupDialog}
+          onboardingStatus={ownerOnboardingStatus}
+        />
+      )}
 
       {/* Decline Request Dialog */}
       <DeclineRequestDialog

--- a/src/features/rentals/components/detail-page/rental-content.tsx
+++ b/src/features/rentals/components/detail-page/rental-content.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/features/rentals/components/detail-page";
 import { RentalStatusProgress } from "./rental-status-progress";
 import { BookingReviewsSection } from "@/features/reviews/components/booking-reviews-section";
+import type { OnboardingStatus } from "@/features/payments/lib/payout-readiness";
 
 interface RentalContentProps {
   rentalDetails: RentalDetails;
@@ -20,6 +21,7 @@ interface RentalContentProps {
   disputePolicyUrl?: string;
   activeDispute?: DisputeWithRelations | null;
   canReview?: boolean;
+  ownerOnboardingStatus?: OnboardingStatus;
 }
 
 export function RentalContent({
@@ -31,6 +33,7 @@ export function RentalContent({
   disputePolicyUrl,
   activeDispute,
   canReview,
+  ownerOnboardingStatus,
 }: RentalContentProps) {
   return (
     <div className="grid grid-cols-1 gap-8 lg:grid-cols-3">
@@ -86,6 +89,7 @@ export function RentalContent({
           disputePolicyUrl={disputePolicyUrl}
           activeDispute={activeDispute}
           canReview={canReview}
+          ownerOnboardingStatus={ownerOnboardingStatus}
         />
         <RentalProtection />
       </div>

--- a/src/features/rentals/components/detail-page/rental-details-server.tsx
+++ b/src/features/rentals/components/detail-page/rental-details-server.tsx
@@ -1,10 +1,11 @@
 import { notFound } from "next/navigation";
-import { rentalDAL, legalDocumentDAL, disputeDAL } from "@/dal";
+import { rentalDAL, legalDocumentDAL, disputeDAL, userDAL } from "@/dal";
 import { LEGAL_DOCUMENT_IDS } from "@/constants/legal-documents";
 import { RentalLayout } from "./rental-layout";
 import { RentalContent } from "./rental-content";
 import { getAuthenticatedUser } from "@/features/auth/utils/session";
 import { BlindReviewService } from "@/features/reviews/services/blind-review-service";
+import { getPayoutReadiness } from "@/features/payments/lib/payout-readiness";
 
 interface RentalDetailsServerProps {
   rentalId: string;
@@ -112,6 +113,19 @@ export async function RentalDetailsServer({
     }
   }
 
+  // When the current user is the owner viewing a pending request, fetch their
+  // Stripe Connect payout readiness so the Approve button can pre-empt the
+  // approve dialog when onboarding is incomplete.
+  let ownerOnboardingStatus;
+  if (isOwner && rentalDetails.status === "pending") {
+    try {
+      const ownerUser = await userDAL.getUserById(userId);
+      ownerOnboardingStatus = getPayoutReadiness(ownerUser).onboardingStatus;
+    } catch {
+      // Non-critical — fall back to the existing 403 redirect path.
+    }
+  }
+
   return (
     <RentalLayout
       rentalDetails={rentalDetails}
@@ -129,6 +143,7 @@ export async function RentalDetailsServer({
         disputePolicyUrl={disputePolicyUrl}
         activeDispute={activeDispute}
         canReview={canReview}
+        ownerOnboardingStatus={ownerOnboardingStatus}
       />
     </RentalLayout>
   );

--- a/src/features/rentals/components/renting-lending/approve-request-dialog.tsx
+++ b/src/features/rentals/components/renting-lending/approve-request-dialog.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { useRouter } from "next/navigation";
 import { CheckCircle, Loader2 } from "lucide-react";
 
 import {
@@ -39,6 +40,7 @@ export function ApproveRequestDialog({
   const [returnInstructions, setReturnInstructions] = useState("");
 
   const approveMutation = useApproveRentalRequest();
+  const router = useRouter();
 
   const handleApprove = async () => {
     try {
@@ -59,7 +61,23 @@ export function ApproveRequestDialog({
       setPickupInstructions("");
       setReturnInstructions("");
       onSuccess?.();
-    } catch {
+    } catch (error) {
+      // Server gated the accept because the owner's Stripe Connect isn't ready.
+      // Send them straight into the JIT onboarding flow, preserving where they
+      // came from so we can return them here on completion.
+      if (
+        error !== null &&
+        typeof error === "object" &&
+        (error as { code?: string }).code === "PAYMENT_SETUP_REQUIRED"
+      ) {
+        const returnTo = encodeURIComponent(
+          window.location.pathname + window.location.search,
+        );
+        router.push(
+          `/dashboard/payments/earnings-and-payouts?returnTo=${returnTo}`,
+        );
+        return;
+      }
       // Error toast is already shown by the mutation hook's onError handler.
       // Close the dialog since the approval attempt is complete.
       onOpenChange(false);

--- a/src/features/rentals/components/renting-lending/lending-card.tsx
+++ b/src/features/rentals/components/renting-lending/lending-card.tsx
@@ -25,6 +25,8 @@ import {
   DeclineRequestDialog,
 } from "@/features/rentals/components/renting-lending";
 import { MessageUserModal } from "@/features/messages/components/message-user-modal";
+import { PayoutSetupRequiredDialog } from "@/features/payments/components/payout-setup-required-dialog";
+import type { OnboardingStatus } from "@/features/payments/lib/payout-readiness";
 
 const getStatusIcon = (status: string) => {
   switch (status) {
@@ -62,12 +64,25 @@ const getStatusColor = (status: string) => {
 
 interface LendingCardProps {
   request: LendingRequestItem;
+  ownerOnboardingStatus?: OnboardingStatus;
 }
 
-export function LendingCard({ request }: LendingCardProps) {
+export function LendingCard({
+  request,
+  ownerOnboardingStatus,
+}: LendingCardProps) {
   const [showApproveDialog, setShowApproveDialog] = useState(false);
+  const [showPayoutSetupDialog, setShowPayoutSetupDialog] = useState(false);
   const [showDeclineDialog, setShowDeclineDialog] = useState(false);
   const [showMessageModal, setShowMessageModal] = useState(false);
+
+  const handleApproveClick = () => {
+    if (ownerOnboardingStatus && ownerOnboardingStatus !== "verified") {
+      setShowPayoutSetupDialog(true);
+    } else {
+      setShowApproveDialog(true);
+    }
+  };
 
   return (
     <Card>
@@ -214,7 +229,7 @@ export function LendingCard({ request }: LendingCardProps) {
                 <>
                   <Button
                     className="bg-primary hover:bg-primary/80 w-full justify-center"
-                    onClick={() => setShowApproveDialog(true)}
+                    onClick={handleApproveClick}
                   >
                     <CheckCircle className="mr-2 h-4 w-4" />
                     Approve Request
@@ -390,7 +405,7 @@ export function LendingCard({ request }: LendingCardProps) {
                     <Button
                       className="bg-primary hover:bg-primary/80 w-full justify-center"
                       size="sm"
-                      onClick={() => setShowApproveDialog(true)}
+                      onClick={handleApproveClick}
                     >
                       <CheckCircle className="mr-2 h-4 w-4" />
                       Approve Request
@@ -452,6 +467,14 @@ export function LendingCard({ request }: LendingCardProps) {
         renterName={request.renterName}
         deliveryRequested={request.deliveryRequested}
       />
+
+      {ownerOnboardingStatus && ownerOnboardingStatus !== "verified" && (
+        <PayoutSetupRequiredDialog
+          open={showPayoutSetupDialog}
+          onOpenChange={setShowPayoutSetupDialog}
+          onboardingStatus={ownerOnboardingStatus}
+        />
+      )}
 
       <DeclineRequestDialog
         open={showDeclineDialog}

--- a/src/features/rentals/components/renting-lending/lending-list.tsx
+++ b/src/features/rentals/components/renting-lending/lending-list.tsx
@@ -17,6 +17,7 @@ import {
 import type { LendingRequestItem } from "@/dal/rentals.dal";
 import { LendingCard } from "@/features/rentals/components/renting-lending";
 import { EmptyStateCoach } from "@/components/empty-state-coach";
+import type { OnboardingStatus } from "@/features/payments/lib/payout-readiness";
 
 interface LendingRequestsListProps {
   data: LendingRequestItem[];
@@ -25,12 +26,14 @@ interface LendingRequestsListProps {
     label: string;
     href: string;
   };
+  ownerOnboardingStatus?: OnboardingStatus;
 }
 
 export function LendingRequestsList({
   data,
   emptyStateMessage,
   emptyStateAction,
+  ownerOnboardingStatus,
 }: LendingRequestsListProps) {
   const [searchQuery, setSearchQuery] = useState("");
   const [sortBy, setSortBy] = useState("newest");
@@ -151,7 +154,11 @@ export function LendingRequestsList({
         <>
           <div className="space-y-4">
             {paginatedData.map((item) => (
-              <LendingCard key={item.id} request={item} />
+              <LendingCard
+                key={item.id}
+                request={item}
+                ownerOnboardingStatus={ownerOnboardingStatus}
+              />
             ))}
           </div>
 

--- a/src/features/rentals/components/renting-lending/rentals-client.tsx
+++ b/src/features/rentals/components/renting-lending/rentals-client.tsx
@@ -27,11 +27,13 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { AlertCircle } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+import type { OnboardingStatus } from "@/features/payments/lib/payout-readiness";
 
 interface RentalsClientProps {
   initialType: "renting" | "lending";
   initialStatus: string;
   reviewPolicyUrl?: string;
+  ownerOnboardingStatus?: OnboardingStatus;
 }
 
 const SCROLL_POSITION_KEY = "rentals-filter-scroll-position";
@@ -40,6 +42,7 @@ export function RentalsClient({
   initialType,
   initialStatus,
   reviewPolicyUrl,
+  ownerOnboardingStatus,
 }: RentalsClientProps) {
   const router = useRouter();
   const pathname = usePathname();
@@ -271,6 +274,7 @@ export function RentalsClient({
       return (
         <LendingRequestsList
           data={data as LendingRequestItem[]}
+          ownerOnboardingStatus={ownerOnboardingStatus}
           emptyStateMessage={
             activeStatus === "incoming"
               ? "No rental requests yet"

--- a/src/features/rentals/hooks/__tests__/use-rental-mutations.test.tsx
+++ b/src/features/rentals/hooks/__tests__/use-rental-mutations.test.tsx
@@ -396,6 +396,41 @@ describe("useApproveRentalRequest", () => {
       }),
     ).rejects.toThrow("Rental request not found");
   });
+
+  it("attaches PAYMENT_SETUP_REQUIRED metadata and suppresses toast on 403", async () => {
+    const errorResponse = {
+      error: "PAYMENT_SETUP_REQUIRED",
+      onboardingStatus: "pending",
+      missingCapabilities: ["payouts"],
+    };
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 403,
+      json: async () => errorResponse,
+    });
+
+    const { result } = renderHook(() => useApproveRentalRequest(), {
+      wrapper: ({ children }) => (
+        <QueryWrapper queryClient={queryClient}>{children}</QueryWrapper>
+      ),
+    });
+
+    let caught: unknown;
+    try {
+      await result.current.mutateAsync({ rentalId: "rental-123" });
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toMatchObject({
+      message: "PAYMENT_SETUP_REQUIRED",
+      code: "PAYMENT_SETUP_REQUIRED",
+      onboardingStatus: "pending",
+      suppressToast: true,
+    });
+    // suppressToast was honored — no error toast was shown.
+    expect(toast.error).not.toHaveBeenCalled();
+  });
 });
 
 describe("useDeclineRentalRequest", () => {

--- a/src/features/rentals/hooks/use-rental-mutations.ts
+++ b/src/features/rentals/hooks/use-rental-mutations.ts
@@ -89,8 +89,19 @@ export function useApproveRentalRequest() {
         const errorObj = new Error(
           error.error || "Failed to approve rental request",
         );
-        // Attach paymentFailed flag if present
-        if (error.paymentFailed) {
+        if (
+          response.status === 403 &&
+          error.error === "PAYMENT_SETUP_REQUIRED"
+        ) {
+          // The dialog catches this code and redirects to the JIT onboarding
+          // page; suppressToast prevents handleMutationError from flashing a
+          // generic error before the navigation happens.
+          Object.assign(errorObj, {
+            code: "PAYMENT_SETUP_REQUIRED",
+            onboardingStatus: error.onboardingStatus,
+            suppressToast: true,
+          });
+        } else if (error.paymentFailed) {
           (errorObj as Error & { paymentFailed?: boolean }).paymentFailed =
             true;
         }

--- a/src/features/rentals/services/approve-rental-request-deposit.test.ts
+++ b/src/features/rentals/services/approve-rental-request-deposit.test.ts
@@ -8,6 +8,12 @@ vi.mock("@/services/stripe/rental-payments", () => ({
   isRetryablePaymentError: vi.fn().mockReturnValue(false),
 }));
 
+vi.mock("@/services/stripe/connect", () => ({
+  getAccountStatus: vi
+    .fn()
+    .mockResolvedValue({ chargesEnabled: true, payoutsEnabled: true }),
+}));
+
 vi.mock("@/services/stripe/deposit-hold", () => ({
   placeDepositHold: (...args: unknown[]) => mockPlaceDepositHold(...args),
 }));
@@ -184,6 +190,10 @@ describe("RentalService.approveRentalRequest — deposit hold failure (UAT-P1-08
               email: "owner@test.com",
               firstName: "Owner",
               lastName: "Test",
+              stripeConnectedAccountId: "acct_123",
+              connectChargesEnabled: true,
+              connectPayoutsEnabled: true,
+              connectOnboardingComplete: true,
             },
       ),
     );

--- a/src/features/rentals/services/rental-service.ts
+++ b/src/features/rentals/services/rental-service.ts
@@ -33,6 +33,7 @@ import {
 } from "@/services/stripe/rental-payments";
 import { placeDepositHold } from "@/services/stripe/deposit-hold";
 import { tryCatch } from "@walkup/walkup-utils";
+import { assertConnectReady } from "@/features/payments/lib/assert-connect-ready";
 import { after } from "next/server";
 
 /**
@@ -403,24 +404,14 @@ export class RentalService {
       );
     }
 
-    // Verify owner's Stripe Connect is set up (needed for later payout)
-    const { data: ownerAccountId, error: accountError } = await tryCatch(
-      userDAL.getConnectedAccountId(rentalRequest.ownerId),
-    );
-    if (accountError || !ownerAccountId) {
-      throw new Error(
-        "Owner must complete Stripe onboarding before receiving payments. Please contact the owner.",
-      );
-    }
-
-    const { data: isOnboarded, error: onboardingCheckError } = await tryCatch(
-      userDAL.isConnectOnboardingComplete(rentalRequest.ownerId),
-    );
-    if (onboardingCheckError || !isOnboarded) {
-      throw new Error(
-        "Owner's Stripe account is not fully set up. Please contact the owner to complete onboarding.",
-      );
-    }
+    // Stripe Connect readiness: fast-path on cached flags, then authoritative
+    // live retrieve. Throws PaymentSetupRequiredError on any failure; the
+    // route handler translates that to a 403 PAYMENT_SETUP_REQUIRED response.
+    // Booking stays in `pending` since we throw before transitioning state.
+    await assertConnectReady(rentalRequest.ownerId, {
+      bookingType: "rental",
+      bookingId: rentalId,
+    });
 
     const totalAmount = Number(rentalRequest.totalAmount);
     const applicationFeeAmount = Number(rentalRequest.applicationFeeAmount);

--- a/src/features/services/__tests__/service-booking-service.test.ts
+++ b/src/features/services/__tests__/service-booking-service.test.ts
@@ -57,6 +57,7 @@ vi.mock("@/dal", () => ({
   },
   userDAL: {
     getUserById: (...a: unknown[]) => mockGetUserById(...a),
+    updateConnectOnboardingStatus: vi.fn().mockResolvedValue(undefined),
   },
 }));
 
@@ -75,6 +76,13 @@ vi.mock("@/services/stripe/refund", () => ({
 
 vi.mock("@/services/stripe/rental-payments", () => ({
   getPaymentErrorMessage: (...a: unknown[]) => mockGetPaymentErrorMessage(...a),
+  isRetryablePaymentError: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock("@/services/stripe/connect", () => ({
+  getAccountStatus: vi
+    .fn()
+    .mockResolvedValue({ chargesEnabled: true, payoutsEnabled: true }),
 }));
 
 vi.mock("@/features/notifications/utils/send-notification", () => ({
@@ -499,6 +507,119 @@ describe("ServiceBookingService", () => {
       );
       expect(mockSendNotification).toHaveBeenCalled();
       expect(mockSendNotification.mock.calls.length).toBeGreaterThanOrEqual(2);
+    });
+
+    describe("Stripe Connect gating", () => {
+      it("throws PaymentSetupRequiredError with not_started when provider has no Stripe Connect account", async () => {
+        mockBookingGetById.mockResolvedValue(bookingPending);
+        mockGetUserById.mockResolvedValue({
+          stripeConnectedAccountId: null,
+          connectChargesEnabled: false,
+          connectPayoutsEnabled: false,
+          connectOnboardingComplete: false,
+        });
+
+        await expect(
+          ServiceBookingService.acceptBooking("book-1", "prov-1", ctx),
+        ).rejects.toMatchObject({
+          code: "PAYMENT_SETUP_REQUIRED",
+          details: {
+            onboardingStatus: "not_started",
+            missingCapabilities: ["charges", "payouts"],
+          },
+        });
+        // Booking state SHALL NOT change when the gate throws.
+        expect(mockBookingUpdate).not.toHaveBeenCalled();
+        expect(mockChargeServicePayment).not.toHaveBeenCalled();
+      });
+
+      it("throws with pending when account exists but capabilities are off", async () => {
+        mockBookingGetById.mockResolvedValue(bookingPending);
+        mockGetUserById.mockResolvedValue({
+          stripeConnectedAccountId: "acct_123",
+          connectChargesEnabled: false,
+          connectPayoutsEnabled: false,
+          connectOnboardingComplete: false,
+        });
+
+        await expect(
+          ServiceBookingService.acceptBooking("book-1", "prov-1", ctx),
+        ).rejects.toMatchObject({
+          code: "PAYMENT_SETUP_REQUIRED",
+          details: { onboardingStatus: "pending" },
+        });
+        expect(mockChargeServicePayment).not.toHaveBeenCalled();
+      });
+
+      it("throws with restricted when payouts capability is off", async () => {
+        mockBookingGetById.mockResolvedValue(bookingPending);
+        mockGetUserById.mockResolvedValue({
+          stripeConnectedAccountId: "acct_123",
+          connectChargesEnabled: true,
+          connectPayoutsEnabled: false,
+          connectOnboardingComplete: true,
+        });
+
+        await expect(
+          ServiceBookingService.acceptBooking("book-1", "prov-1", ctx),
+        ).rejects.toMatchObject({
+          code: "PAYMENT_SETUP_REQUIRED",
+          details: {
+            onboardingStatus: "restricted",
+            missingCapabilities: ["payouts"],
+          },
+        });
+      });
+
+      it("throws with regression when live retrieve shows capability loss after cached said verified", async () => {
+        mockBookingGetById.mockResolvedValue(bookingPending);
+        mockGetUserById.mockResolvedValue({
+          stripeConnectedAccountId: "acct_123",
+          connectChargesEnabled: true,
+          connectPayoutsEnabled: true,
+          connectOnboardingComplete: true,
+        });
+        const { getAccountStatus } = await import("@/services/stripe/connect");
+        vi.mocked(getAccountStatus).mockResolvedValueOnce({
+          chargesEnabled: true,
+          payoutsEnabled: false,
+        });
+
+        await expect(
+          ServiceBookingService.acceptBooking("book-1", "prov-1", ctx),
+        ).rejects.toMatchObject({
+          code: "PAYMENT_SETUP_REQUIRED",
+          details: {
+            onboardingStatus: "restricted",
+            missingCapabilities: ["payouts"],
+          },
+        });
+        expect(mockChargeServicePayment).not.toHaveBeenCalled();
+      });
+
+      it("throws with reason=stripe_unreachable when live retrieve fails", async () => {
+        mockBookingGetById.mockResolvedValue(bookingPending);
+        mockGetUserById.mockResolvedValue({
+          stripeConnectedAccountId: "acct_123",
+          connectChargesEnabled: true,
+          connectPayoutsEnabled: true,
+          connectOnboardingComplete: true,
+        });
+        const { getAccountStatus } = await import("@/services/stripe/connect");
+        vi.mocked(getAccountStatus).mockRejectedValueOnce(
+          new Error("non-transient"),
+        );
+
+        await expect(
+          ServiceBookingService.acceptBooking("book-1", "prov-1", ctx),
+        ).rejects.toMatchObject({
+          code: "PAYMENT_SETUP_REQUIRED",
+          details: {
+            onboardingStatus: "unknown",
+            reason: "stripe_unreachable",
+          },
+        });
+      });
     });
   });
 

--- a/src/features/services/__tests__/service-listing-service.test.ts
+++ b/src/features/services/__tests__/service-listing-service.test.ts
@@ -2,6 +2,14 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { ServiceListingService } from "../services/service-listing-service";
 import { ForbiddenError, NotFoundError, ValidationError } from "@/dal/errors";
 
+const { mockLogGatingEvent } = vi.hoisted(() => ({
+  mockLogGatingEvent: vi.fn(),
+}));
+
+vi.mock("@/features/payments/lib/log-events", () => ({
+  logGatingEvent: mockLogGatingEvent,
+}));
+
 const mockGetUserById = vi.fn();
 const mockListingCreate = vi.fn();
 const mockListingGetById = vi.fn();
@@ -84,11 +92,14 @@ describe("ServiceListingService", () => {
       ownerPoliciesAcknowledged: true,
     };
 
-    it("returns stripe_connect_required when Connect is not ready", async () => {
+    it("creates the listing even when Connect is not ready and emits listing_created_without_stripe_connect", async () => {
       mockGetUserById.mockResolvedValue({
         ...connectUser,
         connectChargesEnabled: false,
+        connectPayoutsEnabled: false,
+        connectOnboardingComplete: false,
       });
+      mockListingCreate.mockResolvedValue(listing);
 
       const result = await ServiceListingService.createListing(
         form,
@@ -96,15 +107,24 @@ describe("ServiceListingService", () => {
         ctx,
       );
 
-      expect(result).toEqual({
-        success: false,
-        error: "stripe_connect_required",
-      });
-      expect(mockListingCreate).not.toHaveBeenCalled();
+      expect(result.success).toBe(true);
+      expect(mockListingCreate).toHaveBeenCalled();
+      expect(mockSendPending).toHaveBeenCalledWith(listing);
+      expect(mockLogGatingEvent).toHaveBeenCalledWith(
+        "listing_created_without_stripe_connect",
+        expect.objectContaining({
+          userId: "prov-1",
+          listingId: "list-1",
+          onboardingStatus: "pending",
+        }),
+      );
     });
 
     it("creates listing and sends admin notification when Connect is active", async () => {
-      mockGetUserById.mockResolvedValue(connectUser);
+      mockGetUserById.mockResolvedValue({
+        ...connectUser,
+        connectOnboardingComplete: true,
+      });
       mockListingCreate.mockResolvedValue(listing);
 
       const result = await ServiceListingService.createListing(
@@ -119,10 +139,14 @@ describe("ServiceListingService", () => {
       }
       expect(mockSendPending).toHaveBeenCalledWith(listing);
       expect(mockAuditCreate).toHaveBeenCalled();
+      expect(mockLogGatingEvent).not.toHaveBeenCalled();
     });
 
     it("passes status pending_approval to DAL create", async () => {
-      mockGetUserById.mockResolvedValue(connectUser);
+      mockGetUserById.mockResolvedValue({
+        ...connectUser,
+        connectOnboardingComplete: true,
+      });
       mockListingCreate.mockResolvedValue(listing);
 
       await ServiceListingService.createListing(form, "prov-1", ctx);

--- a/src/features/services/components/service-booking-detail-client.tsx
+++ b/src/features/services/components/service-booking-detail-client.tsx
@@ -46,6 +46,8 @@ import { TimeWindowValidation } from "@/features/disputes/lib/time-window-valida
 import { ServiceStatusProgress } from "@/features/services/components/detail-page/service-status-progress";
 import { BookingReviewsSection } from "@/features/reviews/components/booking-reviews-section";
 import { ReviewFormDialog } from "@/features/reviews/components/review-form-dialog";
+import { PayoutSetupRequiredDialog } from "@/features/payments/components/payout-setup-required-dialog";
+import type { OnboardingStatus } from "@/features/payments/lib/payout-readiness";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Types
@@ -116,6 +118,12 @@ interface ServiceBookingDetailClientProps {
   priceInCents?: boolean;
   /** Whether the current user can leave a review for this booking. */
   canReview?: boolean;
+  /**
+   * The provider's Stripe Connect payout readiness. Only meaningful when the
+   * current viewer IS the provider; used to pre-check the Accept action and
+   * surface a JIT onboarding dialog when not verified.
+   */
+  providerOnboardingStatus?: OnboardingStatus;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -178,6 +186,7 @@ export function ServiceBookingDetailClient({
   hasActiveDispute = false,
   priceInCents = false,
   canReview: canReviewProp = false,
+  providerOnboardingStatus,
 }: ServiceBookingDetailClientProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -185,6 +194,7 @@ export function ServiceBookingDetailClient({
 
   // Dialog states
   const [acceptOpen, setAcceptOpen] = useState(false);
+  const [payoutSetupOpen, setPayoutSetupOpen] = useState(false);
   const [declineOpen, setDeclineOpen] = useState(false);
   const [cancelOpen, setCancelOpen] = useState(false);
   const [completeOpen, setCompleteOpen] = useState(false);
@@ -282,6 +292,19 @@ export function ServiceBookingDetailClient({
       const data = await res.json().catch(() => ({}));
       if (!res.ok) {
         const body = data as { error?: string; paymentFailed?: boolean };
+        // Server gated the accept because the provider's Stripe Connect isn't
+        // ready. Send them into the JIT onboarding flow, preserving where they
+        // came from so we can return them here on completion. No toast — the
+        // navigation is the user feedback.
+        if (res.status === 403 && body.error === "PAYMENT_SETUP_REQUIRED") {
+          const returnTo = encodeURIComponent(
+            window.location.pathname + window.location.search,
+          );
+          router.push(
+            `/dashboard/payments/earnings-and-payouts?returnTo=${returnTo}`,
+          );
+          return;
+        }
         toast.error(
           body.paymentFailed
             ? "The payment method failed. The requester has been notified to update their payment method."
@@ -648,7 +671,16 @@ export function ServiceBookingDetailClient({
                   <>
                     <Button
                       className="w-full"
-                      onClick={() => setAcceptOpen(true)}
+                      onClick={() => {
+                        if (
+                          providerOnboardingStatus &&
+                          providerOnboardingStatus !== "verified"
+                        ) {
+                          setPayoutSetupOpen(true);
+                        } else {
+                          setAcceptOpen(true);
+                        }
+                      }}
                       disabled={pending}
                     >
                       {pending ? (
@@ -845,6 +877,14 @@ export function ServiceBookingDetailClient({
           </DialogFooter>
         </DialogContent>
       </Dialog>
+
+      {providerOnboardingStatus && providerOnboardingStatus !== "verified" && (
+        <PayoutSetupRequiredDialog
+          open={payoutSetupOpen}
+          onOpenChange={setPayoutSetupOpen}
+          onboardingStatus={providerOnboardingStatus}
+        />
+      )}
 
       <Dialog
         open={declineOpen}

--- a/src/features/services/hooks/__tests__/use-service-bookings.test.tsx
+++ b/src/features/services/hooks/__tests__/use-service-bookings.test.tsx
@@ -345,6 +345,38 @@ describe("useAcceptServiceBooking", () => {
 
     await expect(result.current.mutateAsync()).rejects.toThrow("Cannot accept");
   });
+
+  it("attaches PAYMENT_SETUP_REQUIRED metadata and suppresses toast on 403", async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 403,
+      json: async () => ({
+        error: "PAYMENT_SETUP_REQUIRED",
+        onboardingStatus: "restricted",
+        missingCapabilities: ["payouts"],
+      }),
+    });
+
+    const { result } = renderHook(() => useAcceptServiceBooking("booking-1"), {
+      wrapper: ({ children }) => (
+        <QueryWrapper queryClient={queryClient}>{children}</QueryWrapper>
+      ),
+    });
+
+    let caught: unknown;
+    try {
+      await result.current.mutateAsync();
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toMatchObject({
+      message: "PAYMENT_SETUP_REQUIRED",
+      code: "PAYMENT_SETUP_REQUIRED",
+      onboardingStatus: "restricted",
+      suppressToast: true,
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/features/services/hooks/use-service-bookings.ts
+++ b/src/features/services/hooks/use-service-bookings.ts
@@ -96,7 +96,17 @@ export function useAcceptServiceBooking(bookingId: string) {
       });
       const data = await res.json().catch(() => ({}));
       if (!res.ok) {
-        throw new Error(data.error ?? "Failed to accept booking");
+        const errorObj = new Error(data.error ?? "Failed to accept booking");
+        if (res.status === 403 && data.error === "PAYMENT_SETUP_REQUIRED") {
+          // Caller (UI) redirects to JIT onboarding; suppress the auto-toast
+          // so the user doesn't see a flash of error before the navigation.
+          Object.assign(errorObj, {
+            code: "PAYMENT_SETUP_REQUIRED",
+            onboardingStatus: data.onboardingStatus,
+            suppressToast: true,
+          });
+        }
+        throw errorObj;
       }
       return data as { status: string };
     },

--- a/src/features/services/services/service-booking-service.ts
+++ b/src/features/services/services/service-booking-service.ts
@@ -19,7 +19,9 @@ import {
 import {
   calculateServiceFee,
   PLATFORM_FEE_PERCENTAGE,
+  PENDING_BOOKING_EXPIRY_WINDOW_HOURS,
 } from "@/constants/payments";
+import { assertConnectReady } from "@/features/payments/lib/assert-connect-ready";
 import { sendNotification } from "@/features/notifications/utils/send-notification";
 import { captureNonCriticalError } from "@/lib/api/route-helpers";
 import { sendOpsAlert } from "@/features/notifications/lib/ops-alerts";
@@ -59,18 +61,6 @@ function parseProposedDateTime(
     return new Date();
   }
   return d;
-}
-
-async function assertProviderConnectForCharge(
-  providerId: string,
-): Promise<boolean> {
-  const u = await userDAL.getUserById(providerId);
-  if (!u) return false;
-  return Boolean(
-    u.stripeConnectedAccountId &&
-    u.connectChargesEnabled &&
-    u.connectPayoutsEnabled,
-  );
 }
 
 /**
@@ -143,6 +133,9 @@ export class ServiceBookingService {
       cancellationReason: null,
       completedAt: null,
       selectedPaymentMethodId: formData.paymentMethodId ?? null,
+      expiresAt: new Date(
+        Date.now() + PENDING_BOOKING_EXPIRY_WINDOW_HOURS * 60 * 60 * 1000,
+      ),
     });
 
     await auditLogDAL.create({
@@ -294,13 +287,14 @@ export class ServiceBookingService {
       throw new ValidationError("Booking is not pending", "status");
     }
 
-    const okConnect = await assertProviderConnectForCharge(providerId);
-    if (!okConnect) {
-      throw new ValidationError(
-        "Provider Stripe Connect is not ready to accept payments",
-        "stripe",
-      );
-    }
+    // Stripe Connect readiness: fast-path on cached flags, then authoritative
+    // live retrieve. Throws PaymentSetupRequiredError on any failure; the
+    // route handler translates that to a 403 PAYMENT_SETUP_REQUIRED response.
+    // Booking stays in `pending` since we throw before transitioning state.
+    await assertConnectReady(providerId, {
+      bookingType: "service",
+      bookingId,
+    });
 
     const stripeCtx = await getStripeCustomerContext(detail.requesterId);
     if (!stripeCtx) {

--- a/src/features/services/services/service-listing-service.ts
+++ b/src/features/services/services/service-listing-service.ts
@@ -12,26 +12,12 @@ import {
   sendListingPendingAdminNotification,
   sendListingRejectedNotification,
 } from "@/features/services/notifications/service-notifications";
+import { getPayoutReadiness } from "@/features/payments/lib/payout-readiness";
+import { logGatingEvent } from "@/features/payments/lib/log-events";
 
 import type { AuditContext, CreateListingInput } from "../types";
 
-export type CreateListingResult =
-  | { success: true; listing: ServiceListing }
-  | { success: false; error: "stripe_connect_required" };
-
-async function assertProviderStripeConnect(
-  providerId: string,
-): Promise<boolean> {
-  const profile = await userDAL.getUserById(providerId);
-  if (!profile) {
-    return false;
-  }
-  return Boolean(
-    profile.stripeConnectedAccountId &&
-    profile.connectChargesEnabled &&
-    profile.connectPayoutsEnabled,
-  );
-}
+export type CreateListingResult = { success: true; listing: ServiceListing };
 
 /**
  * Application service for HOA service listings (create, edit, admin approval).
@@ -61,18 +47,14 @@ export class ServiceListingService {
   }
 
   /**
-   * Submits a new listing for admin approval.
+   * Submits a new listing for admin approval. Stripe Connect is NOT required at
+   * this stage; it is enforced just-in-time at booking acceptance.
    */
   static async createListing(
     formData: CreateListingInput,
     providerId: string,
     context: AuditContext,
   ): Promise<CreateListingResult> {
-    const okConnect = await assertProviderStripeConnect(providerId);
-    if (!okConnect) {
-      return { success: false, error: "stripe_connect_required" };
-    }
-
     const listing = await serviceListingDAL.create({
       communityId: formData.communityId,
       providerId,
@@ -87,6 +69,21 @@ export class ServiceListingService {
       adminNote: null,
       rejectionReason: null,
     });
+
+    const user = await userDAL.getUserById(providerId);
+    const readiness = getPayoutReadiness({
+      stripeConnectedAccountId: user.stripeConnectedAccountId ?? null,
+      connectChargesEnabled: user.connectChargesEnabled,
+      connectPayoutsEnabled: user.connectPayoutsEnabled,
+      connectOnboardingComplete: user.connectOnboardingComplete,
+    });
+    if (readiness.onboardingStatus !== "verified") {
+      logGatingEvent("listing_created_without_stripe_connect", {
+        userId: providerId,
+        listingId: listing.id,
+        onboardingStatus: readiness.onboardingStatus,
+      });
+    }
 
     await auditLogDAL.create({
       entityType: "service_listing",

--- a/src/lib/api/route-helpers.ts
+++ b/src/lib/api/route-helpers.ts
@@ -17,6 +17,7 @@ import {
   ConflictError,
   ServiceBookingPaymentFailedError,
 } from "@/dal/errors";
+import { PaymentSetupRequiredError } from "@/features/payments/lib/errors";
 import { setSentryUser } from "@/lib/sentry/user-context";
 
 /**
@@ -56,7 +57,8 @@ export function handleApiError(
     !(error instanceof UnauthorizedError) &&
     !(error instanceof NotFoundError) &&
     !(error instanceof ValidationError) &&
-    !(error instanceof ConflictError);
+    !(error instanceof ConflictError) &&
+    !(error instanceof PaymentSetupRequiredError);
 
   if (shouldCaptureError) {
     const ctx = getRequestContext();
@@ -112,6 +114,20 @@ export function handleApiError(
         paymentFailed: true,
       },
       { status: 400 },
+    );
+  }
+
+  if (error instanceof PaymentSetupRequiredError) {
+    return NextResponse.json(
+      {
+        error: error.code,
+        onboardingStatus: error.details.onboardingStatus,
+        ...(error.details.missingCapabilities && {
+          missingCapabilities: error.details.missingCapabilities,
+        }),
+        ...(error.details.reason && { reason: error.details.reason }),
+      },
+      { status: error.statusCode },
     );
   }
 

--- a/src/lib/react-query/mutation-helpers.ts
+++ b/src/lib/react-query/mutation-helpers.ts
@@ -7,14 +7,24 @@ import { toast } from "sonner";
 import type { QueryKey } from "@tanstack/react-query";
 
 /**
- * Standard mutation error handler
- * Shows toast notification with error message
- * If customMessage is provided, it takes precedence over the error's message
+ * Standard mutation error handler. Shows toast notification with error message.
+ * If customMessage is provided, it takes precedence over the error's message.
+ *
+ * Errors marked with `suppressToast: true` bypass the toast — the caller is
+ * expected to drive user feedback another way (e.g., a redirect).
  */
 export function handleMutationError(
   error: unknown,
   customMessage?: string,
 ): void {
+  if (
+    error !== null &&
+    typeof error === "object" &&
+    (error as { suppressToast?: boolean }).suppressToast === true
+  ) {
+    return;
+  }
+
   const errorMessage = customMessage
     ? customMessage
     : error instanceof Error


### PR DESCRIPTION
- Added `payout-readiness.ts` to define types and logic for determining user payout readiness based on Stripe Connect status.
- Introduced `validateReturnTo` function in `return-to.ts` for secure handling of redirect URLs in onboarding flow.
- Updated rental actions to show a payout setup dialog if the owner's onboarding status is not verified before approving a rental request.
- Enhanced rental content and detail components to pass owner onboarding status for conditional rendering of dialogs.
- Integrated payout readiness checks in rental detail server logic to fetch and handle onboarding status.
- Modified approve request dialog to redirect users to onboarding if their Stripe Connect setup is incomplete.
- Updated lending card and list components to handle payout setup dialogs based on onboarding status.
- Enhanced service booking detail client to manage onboarding status and redirect users to onboarding flow as needed.
- Added tests to ensure proper handling of payment setup requirements and onboarding status in rental and service booking flows.
- Refactored service listing creation to log events when listings are created without Stripe Connect readiness.